### PR TITLE
Always save ccache, even on build failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,6 @@ runs:
   using: "node12"
   main: "dist/restore/index.js"
   post: "dist/save/index.js"
-  post-if: "success()"
 branding:
   icon: "archive"
   color: "gray-dark"


### PR DESCRIPTION
In the case of ccache, just because a build fails is not a reason not to save the cache. The intermediate cached data is still very useful for speeding up the following build which hopefully fixes the build failure.