### PR TITLE
Update package manager index before installing ccache

### DIFF
--- a/src/restore.ts
+++ b/src/restore.ts
@@ -8,8 +8,10 @@ import * as cache from "@actions/cache";
 
 async function install() {
   if (process.platform === "darwin") {
+    await exec.exec("brew update");
     await exec.exec("brew install ccache");
   } else {
+    await exec.exec("sudo apt-get update");
     await exec.exec("sudo apt-get install -y ccache");
   }
 }

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -7,12 +7,18 @@ import * as cache from "@actions/cache";
 // based on https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
 
 async function install() {
+  const run = async (command: string) => {
+    core.startGroup(command);
+    await exec.exec(command);
+    core.endGroup();
+  };
+
   if (process.platform === "darwin") {
-    await exec.exec("brew update");
-    await exec.exec("brew install ccache");
+    await run("brew update");
+    await run("brew install ccache");
   } else {
-    await exec.exec("sudo apt-get update");
-    await exec.exec("sudo apt-get install -y ccache");
+    await run("sudo apt-get update");
+    await run("sudo apt-get install -y ccache");
   }
 }
 


### PR DESCRIPTION
This is to avoid the index being outdated and failing ccache installation.

Relevant issues:
https://github.com/actions/virtual-environments/issues/1757#issuecomment-765238242
https://github.com/actions/virtual-environments/issues/2924

From https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners:
>Note: Always run sudo apt-get update before installing a package. In case the apt index is stale, this
>command fetches and re-indexes any available packages, which helps prevent package installation failures.