### PR TITLE
Improve cache key handling

### DIFF
--- a/src/restore.ts
+++ b/src/restore.ts
@@ -15,24 +15,22 @@ async function install() {
 }
 
 async function restore() {
-  let restoreKey = `ccache-`;
+  let restoreKey = `ccache`;
 
-  let inputKey = core.getInput("key");
+  const inputKey = core.getInput("key");
   if (inputKey) {
-    restoreKey += `${inputKey}-`;
+    restoreKey += `-${inputKey}`;
   }
 
   const restoreKeys = [
     restoreKey
   ]
-  
-  const key = restoreKey + new Date().toISOString();
 
   const paths = [
     '.ccache'
-  ]  
+  ]
 
-  const restoredWith = await cache.restoreCache(paths, key, restoreKeys)
+  const restoredWith = await cache.restoreCache(paths, restoreKey, restoreKeys)
   if (restoredWith) {
     core.info(`Restored from cache key "${restoredWith}".`);
   } else {
@@ -43,7 +41,7 @@ async function restore() {
 async function configure() {
   const ghWorkSpace = process.env.GITHUB_WORKSPACE;
   const maxSize = core.getInput('max-size');
-  
+
   core.info("Configure ccache");
   await exec.exec("ccache --set-config=cache_dir=" + ghWorkSpace + "/.ccache");
   await exec.exec("ccache --set-config=max_size=" + maxSize);

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -15,7 +15,7 @@ async function install() {
 }
 
 async function restore() {
-  let restoreKey = `ccache`;
+  let restoreKey = `ccache_action`;
 
   const inputKey = core.getInput("key");
   if (inputKey) {

--- a/src/save.ts
+++ b/src/save.ts
@@ -7,20 +7,19 @@ async function run() : Promise<void> {
     core.info("Ccache stats:")
     await exec.exec("ccache -s");
 
-    let restoreKey = `ccache-`;
-    let inputKey = core.getInput("key");
+    let saveKey = `ccache`;
 
+    const inputKey = core.getInput("key");
     if (inputKey) {
-      restoreKey += `${inputKey}-`;
+      saveKey += `-${inputKey}`;
     }
 
-    const key = restoreKey + new Date().toISOString();
     const paths = [
       '.ccache'
     ]
-  
-    core.info(`Save cache using key "${key}".`)
-    await cache.saveCache(paths, key);
+
+    core.info(`Save cache using key "${saveKey}".`)
+    await cache.saveCache(paths, saveKey);
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/src/save.ts
+++ b/src/save.ts
@@ -7,7 +7,7 @@ async function run() : Promise<void> {
     core.info("Ccache stats:")
     await exec.exec("ccache -s");
 
-    let saveKey = `ccache`;
+    let saveKey = `ccache_action`;
 
     const inputKey = core.getInput("key");
     if (inputKey) {


### PR DESCRIPTION
* Don't use date in cache key
  Having date in cache key means a new cache entry will be generated for every job. However this prohibits the behavior of using 1 (fixed) cache entry for every job.
  This also produce more consistent behavior when the cache is nearly full, i.e. update existing cache entry instead of evicting older entries (possibly other non-ccache entries).
  Note that the user can still specify additional cache key to customize the behavior.
* Use more specific name for cache key
  This reduce the possibility of a name clash.
