### PR TITLE
Don't fail the entire CI run just because of cache saving error

### DIFF
--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -58331,7 +58331,9 @@ async function run() {
         }
     }
     catch (error) {
-        _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(`Saving cache failed: ${error}`);
+        // A failure to save cache shouldn't prevent the entire CI run from
+        // failing, so do not call setFailed() here.
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.warning(`Saving cache failed: ${error}`);
     }
 }
 run();

--- a/src/save.ts
+++ b/src/save.ts
@@ -66,7 +66,9 @@ async function run() : Promise<void> {
       await cache.saveCache(paths, saveKey);
     }
   } catch (error) {
-    core.setFailed(`Saving cache failed: ${error}`);
+    // A failure to save cache shouldn't prevent the entire CI run from
+    // failing, so do not call setFailed() here.
+    core.warning(`Saving cache failed: ${error}`);
   }
 }
 


### PR DESCRIPTION
I'm getting relatively regularly the following mysterious errors from "Post Install CCache" step:
```
Error: Saving cache failed: Error: uploadChunk (start: 100663296, end: 134217727) failed: Cache service responded with 503
```
I guess there is nothing that can be really done about it (except retrying perhaps?), but I'd strongly prefer if the build succeeded, instead of failing, if this is the only error in it -- after all it's a cache, it's not crucial and failing to save it shouldn't make the entire CI run fail.