### PR TITLE
Make cache key timestamping optional.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -186,3 +186,16 @@ jobs:
         uses: ./
         with:
           save: ${{ matrix.save }}
+
+  test_option_append_timestamp:
+    # Test that the 'append-timestamp' option is available.
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        append-timestamp: [true, false]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run ccache-action
+        uses: ./
+        with:
+          append-timestamp: ${{ matrix.append-timestamp }}

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,9 @@ inputs:
   save:
     description: "If 'false', do not save the cache, only restore."
     default: true
-
+  use-timestamp:
+      description: "Append a timestamp to the cache key (default: true)"
+      default: true
 runs:
   using: "node16"
   main: "dist/restore/index.js"

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
   save:
     description: "If 'false', do not save the cache, only restore."
     default: true
-  use-timestamp:
+  append-timestamp:
       description: "Append a timestamp to the cache key (default: true)"
       default: true
 runs:

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -59294,6 +59294,7 @@ async function runInner() {
     const ccacheVariant = core.getInput("variant");
     core.saveState("ccacheVariant", ccacheVariant);
     core.saveState("shouldSave", core.getBooleanInput("save"));
+    core.saveState("useTimestamp", core.getBooleanInput("use-timestamp"));
     let ccachePath = await io.which(ccacheVariant);
     if (!ccachePath) {
         core.startGroup(`Install ${ccacheVariant}`);

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -1013,7 +1013,7 @@ function retry(name, method, getStatusCode, maxAttempts = constants_1.DefaultRet
 exports.retry = retry;
 function retryTypedResponse(name, method, maxAttempts = constants_1.DefaultRetryAttempts, delay = constants_1.DefaultRetryDelay) {
     return __awaiter(this, void 0, void 0, function* () {
-        return yield retry(name, method, (response) => response.statusCode, maxAttempts, delay, 
+        return yield retry(name, method, (response) => response.statusCode, maxAttempts, delay,
         // If the error object contains the statusCode property, extract it and return
         // an TypedResponse<T> so it can be processed by the retry logic.
         (error) => {
@@ -1847,8 +1847,8 @@ class OidcClient {
             const res = yield httpclient
                 .getJson(id_token_url)
                 .catch(error => {
-                throw new Error(`Failed to get ID Token. \n 
-        Error Code : ${error.statusCode}\n 
+                throw new Error(`Failed to get ID Token. \n
+        Error Code : ${error.statusCode}\n
         Error Message: ${error.result.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
@@ -7042,7 +7042,7 @@ class Serializer {
     /**
      * The provided model mapper.
      */
-    modelMappers = {}, 
+    modelMappers = {},
     /**
      * Whether the contents are XML or not.
      */
@@ -9369,7 +9369,7 @@ class BaseRequestPolicy {
     /**
      * The next policy in the pipeline. Each policy is responsible for executing the next one if the request is to continue through the pipeline.
      */
-    _nextPolicy, 
+    _nextPolicy,
     /**
      * The options that can be passed to a given request policy.
      */
@@ -10401,7 +10401,7 @@ function createTokenCycler(credential, scopes, tokenCyclerOptions) {
             const tryGetAccessToken = () => credential.getToken(scopes, getTokenOptions);
             // Take advantage of promise chaining to insert an assignment to `token`
             // before the refresh can be considered done.
-            refreshWorker = beginRefresh(tryGetAccessToken, options.retryIntervalInMs, 
+            refreshWorker = beginRefresh(tryGetAccessToken, options.retryIntervalInMs,
             // If we don't have a token, then we should timeout immediately
             (_a = token === null || token === void 0 ? void 0 : token.expiresOnTimestamp) !== null && _a !== void 0 ? _a : Date.now())
                 .then((_token) => {
@@ -11208,7 +11208,7 @@ class ServiceClient {
      * @param credentials - The credentials used for authentication with the service.
      * @param options - The service client options that govern the behavior of the client.
      */
-    constructor(credentials, 
+    constructor(credentials,
     /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options */
     options) {
         if (!options) {
@@ -35719,7 +35719,7 @@ const fsCreateReadStream = fs.createReadStream;
  * append blob, or page blob.
  */
 class BlobClient extends StorageClient {
-    constructor(urlOrConnectionString, credentialOrPipelineOrContainerName, blobNameOrOptions, 
+    constructor(urlOrConnectionString, credentialOrPipelineOrContainerName, blobNameOrOptions,
     // Legacy, no fix for eslint error without breaking. Disable it for this interface.
     /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options*/
     options) {
@@ -36757,7 +36757,7 @@ class BlobClient extends StorageClient {
  * AppendBlobClient defines a set of operations applicable to append blobs.
  */
 class AppendBlobClient extends BlobClient {
-    constructor(urlOrConnectionString, credentialOrPipelineOrContainerName, blobNameOrOptions, 
+    constructor(urlOrConnectionString, credentialOrPipelineOrContainerName, blobNameOrOptions,
     // Legacy, no fix for eslint error without breaking. Disable it for this interface.
     /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options*/
     options) {
@@ -37009,7 +37009,7 @@ class AppendBlobClient extends BlobClient {
  * BlockBlobClient defines a set of operations applicable to block blobs.
  */
 class BlockBlobClient extends BlobClient {
-    constructor(urlOrConnectionString, credentialOrPipelineOrContainerName, blobNameOrOptions, 
+    constructor(urlOrConnectionString, credentialOrPipelineOrContainerName, blobNameOrOptions,
     // Legacy, no fix for eslint error without breaking. Disable it for this interface.
     /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options*/
     options) {
@@ -37624,7 +37624,7 @@ class BlockBlobClient extends BlobClient {
                 if (options.onProgress) {
                     options.onProgress({ loadedBytes: transferProgress });
                 }
-            }, 
+            },
             // concurrency should set a smaller value than maxConcurrency, which is helpful to
             // reduce the possibility when a outgoing handler waits for stream data, in
             // this situation, outgoing handlers are blocked.
@@ -37649,7 +37649,7 @@ class BlockBlobClient extends BlobClient {
  * PageBlobClient defines a set of operations applicable to page blobs.
  */
 class PageBlobClient extends BlobClient {
-    constructor(urlOrConnectionString, credentialOrPipelineOrContainerName, blobNameOrOptions, 
+    constructor(urlOrConnectionString, credentialOrPipelineOrContainerName, blobNameOrOptions,
     // Legacy, no fix for eslint error without breaking. Disable it for this interface.
     /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options*/
     options) {
@@ -38540,7 +38540,7 @@ class BatchHeaderFilterPolicyFactory {
  * @see https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch
  */
 class BlobBatchClient {
-    constructor(url, credentialOrPipeline, 
+    constructor(url, credentialOrPipeline,
     // Legacy, no fix for eslint error without breaking. Disable it for this interface.
     /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options*/
     options) {
@@ -38572,7 +38572,7 @@ class BlobBatchClient {
     createBatch() {
         return new BlobBatch();
     }
-    async deleteBlobs(urlsOrBlobClients, credentialOrOptions, 
+    async deleteBlobs(urlsOrBlobClients, credentialOrOptions,
     // Legacy, no fix for eslint error without breaking. Disable it for this interface.
     /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options*/
     options) {
@@ -38587,7 +38587,7 @@ class BlobBatchClient {
         }
         return this.submitBatch(batch);
     }
-    async setBlobsAccessTier(urlsOrBlobClients, credentialOrTier, tierOrOptions, 
+    async setBlobsAccessTier(urlsOrBlobClients, credentialOrTier, tierOrOptions,
     // Legacy, no fix for eslint error without breaking. Disable it for this interface.
     /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options*/
     options) {
@@ -38679,7 +38679,7 @@ class BlobBatchClient {
  * A ContainerClient represents a URL to the Azure Storage container allowing you to manipulate its blobs.
  */
 class ContainerClient extends StorageClient {
-    constructor(urlOrConnectionString, credentialOrPipelineOrContainerName, 
+    constructor(urlOrConnectionString, credentialOrPipelineOrContainerName,
     // Legacy, no fix for eslint error without breaking. Disable it for this interface.
     /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options*/
     options) {
@@ -40138,7 +40138,7 @@ function generateAccountSASQueryParameters(accountSASSignatureValues, sharedKeyC
  * to manipulate blob containers.
  */
 class BlobServiceClient extends StorageClient {
-    constructor(url, credentialOrPipeline, 
+    constructor(url, credentialOrPipeline,
     // Legacy, no fix for eslint error without breaking. Disable it for this interface.
     /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options*/
     options) {
@@ -40170,7 +40170,7 @@ class BlobServiceClient extends StorageClient {
      *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
      * @param options - Optional. Options to configure the HTTP pipeline.
      */
-    static fromConnectionString(connectionString, 
+    static fromConnectionString(connectionString,
     // Legacy, no fix for eslint error without breaking. Disable it for this interface.
     /* eslint-disable-next-line @azure/azure-sdk/ts-naming-options*/
     options) {
@@ -59060,7 +59060,7 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/ 	
+/******/
 /******/ 	// The require function
 /******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -59074,7 +59074,7 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/ 	
+/******/
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
@@ -59083,11 +59083,11 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
 /******/ 		}
-/******/ 	
+/******/
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/ 	
+/******/
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
@@ -59100,7 +59100,7 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /******/ 			return getter;
 /******/ 		};
 /******/ 	})();
-/******/ 	
+/******/
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
@@ -59112,12 +59112,12 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /******/ 			}
 /******/ 		};
 /******/ 	})();
-/******/ 	
+/******/
 /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
 /******/ 	(() => {
 /******/ 		__nccwpck_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
 /******/ 	})();
-/******/ 	
+/******/
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
 /******/ 		// define __esModule on exports
@@ -59128,11 +59128,11 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/ 	
+/******/
 /******/ 	/* webpack/runtime/compat */
-/******/ 	
+/******/
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
+/******/
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be in strict mode.
@@ -59227,9 +59227,9 @@ async function installCcacheLinux() {
     await execBashSudo("apt-get install -y ccache");
 }
 async function installCcacheWindows() {
-    await installCcacheFromGitHub("4.7.4", "windows-x86_64", 
+    await installCcacheFromGitHub("4.7.4", "windows-x86_64",
     // sha256sum of ccache.exe
-    "ac5918ea5df06d4cd2f2ca085955d29fe2a161f229e7cdf958dcf3e8fd5fe80e", 
+    "ac5918ea5df06d4cd2f2ca085955d29fe2a161f229e7cdf958dcf3e8fd5fe80e",
     // TODO find a better place
     `${external_process_namespaceObject.env.USERPROFILE}\\.cargo\\bin`, "ccache.exe");
 }
@@ -59240,7 +59240,7 @@ async function installSccacheLinux() {
     await installSccacheFromGitHub("v0.3.0", "x86_64-unknown-linux-musl", "594b4323aaee02d3b5e1e19c20eb63acb53fd8ecd3c0a3e43618a6e9e36af2fe", "/usr/local/bin/", "sccache");
 }
 async function installSccacheWindows() {
-    await installSccacheFromGitHub("v0.3.0", "x86_64-pc-windows-msvc", "e58646b1c377c7f873c7e13ae7298631fb490703ee15ad67ce326ed0dde2067e", 
+    await installSccacheFromGitHub("v0.3.0", "x86_64-pc-windows-msvc", "e58646b1c377c7f873c7e13ae7298631fb490703ee15ad67ce326ed0dde2067e",
     // TODO find a better place
     `${external_process_namespaceObject.env.USERPROFILE}\\.cargo\\bin`, "sccache.exe");
 }
@@ -59294,7 +59294,7 @@ async function runInner() {
     const ccacheVariant = core.getInput("variant");
     core.saveState("ccacheVariant", ccacheVariant);
     core.saveState("shouldSave", core.getBooleanInput("save"));
-    core.saveState("useTimestamp", core.getBooleanInput("use-timestamp"));
+    core.saveState("appendTimestamp", core.getBooleanInput("append-timestamp"));
     let ccachePath = await io.which(ccacheVariant);
     if (!ccachePath) {
         core.startGroup(`Install ${ccacheVariant}`);

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -59202,7 +59202,10 @@ async function run() {
             _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Not saving cache because no objects are cached.");
         }
         else {
-            const saveKey = primaryKey + new Date().toISOString();
+            let saveKey = primaryKey;
+            if (_actions_core__WEBPACK_IMPORTED_MODULE_0__.getState("useTimestamp")) {
+              saveKey += new Date().toISOString();
+            }
             const paths = [`.${ccacheVariant}`];
             _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Save cache using key "${saveKey}".`);
             await _actions_cache__WEBPACK_IMPORTED_MODULE_1__.saveCache(paths, saveKey);

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -59204,7 +59204,7 @@ async function run() {
         else {
             let saveKey = primaryKey;
             if (_actions_core__WEBPACK_IMPORTED_MODULE_0__.getState("useTimestamp")) {
-              saveKey += new Date().toISOString();
+                saveKey += new Date().toISOString();
             }
             const paths = [`.${ccacheVariant}`];
             _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Save cache using key "${saveKey}".`);

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -157,6 +157,7 @@ async function runInner() : Promise<void> {
   const ccacheVariant = core.getInput("variant");
   core.saveState("ccacheVariant", ccacheVariant);
   core.saveState("shouldSave", core.getBooleanInput("save"));
+  core.saveState("appendTimestamp", core.getBooleanInput("append-timestamp"));
   let ccachePath = await io.which(ccacheVariant);
   if (!ccachePath) {
     core.startGroup(`Install ${ccacheVariant}`);

--- a/src/save.ts
+++ b/src/save.ts
@@ -60,7 +60,7 @@ async function run() : Promise<void> {
       core.info("Not saving cache because no objects are cached.");
     } else {
       let saveKey = primaryKey;
-      if (core.getState("useTimestamp")) {
+      if (core.getState("appendTimestamp")) {
         saveKey += new Date().toISOString();
       }
       const paths = [`.${ccacheVariant}`];

--- a/src/save.ts
+++ b/src/save.ts
@@ -59,7 +59,10 @@ async function run() : Promise<void> {
     if (await ccacheIsEmpty(ccacheVariant, ccacheKnowsVerbosityFlag)) {
       core.info("Not saving cache because no objects are cached.");
     } else {
-      const saveKey = primaryKey + new Date().toISOString();
+      let saveKey = primaryKey;
+      if (core.getState("useTimestamp")) {
+        saveKey += new Date().toISOString();
+      }
       const paths = [`.${ccacheVariant}`];
     
       core.info(`Save cache using key "${saveKey}".`);


### PR DESCRIPTION
Prompted by #117.

For Github repositories with many different actions and concurrent PRs, `ccache-action`'s timestamps can quickly fill up the cache and evict other cached entries. This PR adds an option to disable timestamping. 

I am not familiar with either Javascript or Github Actions, so suggestions on how to improve this are very much welcome. 