### PR TITLE
Small fixes to optional timestamping.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,8 +21,9 @@ inputs:
     description: "If 'false', do not save the cache, only restore."
     default: true
   append-timestamp:
-      description: "Append a timestamp to the cache key (default: true)"
-      default: true
+    description: "Append a timestamp to the cache key (default: true)"
+    default: true
+    required: false
 runs:
   using: "node16"
   main: "dist/restore/index.js"

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -59337,8 +59337,10 @@ async function run() {
         }
         else {
             let saveKey = primaryKey;
-            if (_actions_core__WEBPACK_IMPORTED_MODULE_0__.getState("appendTimestamp")) {
+            if (_actions_core__WEBPACK_IMPORTED_MODULE_0__.getState("appendTimestamp") == "true") {
                 saveKey += new Date().toISOString();
+            } else {
+                _actions_core__WEBPACK_IMPORTED_MODULE_0__.info("Not appending timestamp because 'append-timestamp' is set to 'false'.");
             }
             const paths = [`.${ccacheVariant}`];
             _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Save cache using key "${saveKey}".`);

--- a/src/save.ts
+++ b/src/save.ts
@@ -60,8 +60,10 @@ async function run() : Promise<void> {
       core.info("Not saving cache because no objects are cached.");
     } else {
       let saveKey = primaryKey;
-      if (core.getState("appendTimestamp")) {
+      if (core.getState("appendTimestamp") == "true") {
         saveKey += new Date().toISOString();
+      } else {
+        core.info("Not appending timestamp because 'append-timestamp' is set to 'false'.");
       }
       const paths = [`.${ccacheVariant}`];
     


### PR DESCRIPTION
It looks like the values from `getState` are strings, so an explicit comparison is necessary.