### PR TITLE
Give a clear error message if ccache can't be installed

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -59358,6 +59358,9 @@ async function installCcacheMac() {
     await execBash("brew install ccache");
 }
 async function installCcacheLinux() {
+    if (!await io.which("apt-get")) {
+        throw Error("Can't install ccache automatically under this platform, please install it yourself before using this action.");
+    }
     await execBashSudo("apt-get install -y ccache");
 }
 async function installCcacheWindows() {

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -62,6 +62,9 @@ async function installCcacheMac() : Promise<void> {
 }
 
 async function installCcacheLinux() : Promise<void> {
+  if (!await io.which("apt-get")) {
+    throw Error("Can't install ccache automatically under this platform, please install it yourself before using this action.")
+  }
   await execBashSudo("apt-get install -y ccache");
 }
 


### PR DESCRIPTION
This is not as nice as installing it ourselves, but this isn't that easy to do in general, while giving a message explaining what needs to be done is pretty simple, so do at least this.

See #131.