### PR TITLE
Add Alpine (apk package manager) native install support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,7 +163,7 @@ jobs:
         run: |
           [[ ${{ steps.restore-keys.outputs.test-cache-hit }} = true ]]
 
-  test_docker:
+  test_docker_ubuntu:
     # Test that it works in a Docker container without sudo.
     runs-on: ubuntu-latest
     container: ubuntu:latest
@@ -171,6 +171,17 @@ jobs:
       - uses: actions/checkout@v2
       - run: apt update
         shell: bash
+      - name: Run ccache-action
+        uses: ./
+
+  test_docker_alpine:
+    # Test that it works in Alpine Docker container with apk package manager.
+    runs-on: ubuntu-latest
+    container: alpine:latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: apk update
+        shell: sh
       - name: Run ccache-action
         uses: ./
 

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -59426,10 +59426,15 @@ async function installCcacheMac() {
     await execBash("brew install ccache");
 }
 async function installCcacheLinux() {
-    if (!await io.which("apt-get")) {
-        throw Error("Can't install ccache automatically under this platform, please install it yourself before using this action.");
+    if (await io.which("apt-get")) {
+        await execBashSudo("apt-get install -y ccache");
+        return;
     }
-    await execBashSudo("apt-get install -y ccache");
+    else if (await io.which("apk")) {
+        await execBash("apk add ccache");
+        return;
+    }
+    throw Error("Can't install ccache automatically under this platform, please install it yourself before using this action.");
 }
 async function installCcacheWindows() {
     await installCcacheFromGitHub("4.7.4", "windows-x86_64", 
@@ -59450,7 +59455,7 @@ async function installSccacheWindows() {
     `${external_process_namespaceObject.env.USERPROFILE}\\.cargo\\bin`, "sccache.exe");
 }
 async function execBash(cmd) {
-    await exec.exec("bash", ["-xc", cmd]);
+    await exec.exec("sh", ["-xc", cmd]);
 }
 async function execBashSudo(cmd) {
     await execBash("$(which sudo) " + cmd);

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -62,10 +62,14 @@ async function installCcacheMac() : Promise<void> {
 }
 
 async function installCcacheLinux() : Promise<void> {
-  if (!await io.which("apt-get")) {
-    throw Error("Can't install ccache automatically under this platform, please install it yourself before using this action.")
+  if (await io.which("apt-get")) {
+    await execBashSudo("apt-get install -y ccache");
+    return;
+  } else if (await io.which("apk")) {
+    await execBash("apk add ccache");
+    return;
   }
-  await execBashSudo("apt-get install -y ccache");
+  throw Error("Can't install ccache automatically under this platform, please install it yourself before using this action.");
 }
 
 async function installCcacheWindows() : Promise<void> {
@@ -106,7 +110,7 @@ async function installSccacheWindows() : Promise<void> {
 }
 
 async function execBash(cmd : string) {
-  await exec.exec("bash", ["-xc", cmd]);
+  await exec.exec("sh", ["-xc", cmd]);
 }
 
 async function execBashSudo(cmd : string) {


### PR DESCRIPTION
Fix #131

Also fix `bash` is not present on some slim Ubuntu/Debian Docker images nor on Alpine by default. `sh` in contrast is present on almost any platform.

CI should be passing, tested inside my fork.