### PR TITLE
Add a new flag `create-symlink`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -210,3 +210,23 @@ jobs:
         uses: ./
         with:
           append-timestamp: ${{ matrix.append-timestamp }}
+
+  test_option_create_symlink:
+    # Test that the 'create-symlink' option is available.
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        create-symlink: [true, false]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run ccache-action
+        uses: ./
+        with:
+          create-symlink: ${{ matrix.create-symlink }}
+      - name: Test symlink
+        run: |
+          if [ ${{ matrix.create-symlink }} = true ]; then
+            ls -l $(which gcc) | grep $(which ccache)
+          else
+            ls -l $(which gcc) | grep -v $(which ccache)
+          fi

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ or by manipulating `PATH` (ccache only):
 
 (works for both `ubuntu` and `macos`)
 
+or by setting create-symlink to `true`:
+
+```yaml
+- name: ccache
+  uses: hendrikmuhs/ccache-action@v1.2
+  with:
+    create-symlink: true
+```
+
+
 Ccache/sccache gets installed by this action if it is not installed yet.
 
 ### Example workflow

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "Append a timestamp to the cache key (default: true)"
     default: true
     required: false
+  create-symlink:
+    description: "If set to 'true', create symlinks for ccache in /usr/local/bin to override default toolchains"
+    default: false
+    required: false
 runs:
   using: "node16"
   main: "dist/restore/index.js"

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -59626,6 +59626,15 @@ async function configure(ccacheVariant, platform) {
         if (platform === "darwin") {
             await execBash(`ccache --set-config=compiler_check=content`);
         }
+        if (core.getBooleanInput("create-symlink")) {
+            const ccache = await io.which("ccache");
+            await execBash(`ln -s ${ccache} /usr/local/bin/gcc`);
+            await execBash(`ln -s ${ccache} /usr/local/bin/g++`);
+            await execBash(`ln -s ${ccache} /usr/local/bin/cc`);
+            await execBash(`ln -s ${ccache} /usr/local/bin/c++`);
+            await execBash(`ln -s ${ccache} /usr/local/bin/clang`);
+            await execBash(`ln -s ${ccache} /usr/local/bin/clang++`);
+        }
         core.info("Cccache config:");
         await execBash("ccache -p");
     }

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -56,6 +56,15 @@ async function configure(ccacheVariant : string, platform : string) : Promise<vo
     if (platform === "darwin") {
       await execBash(`ccache --set-config=compiler_check=content`);
     }
+    if (core.getBooleanInput("create-symlink")) {
+      const ccache = await io.which("ccache");
+      await execBash(`ln -s ${ccache} /usr/local/bin/gcc`);
+      await execBash(`ln -s ${ccache} /usr/local/bin/g++`);
+      await execBash(`ln -s ${ccache} /usr/local/bin/cc`);
+      await execBash(`ln -s ${ccache} /usr/local/bin/c++`);
+      await execBash(`ln -s ${ccache} /usr/local/bin/clang`);
+      await execBash(`ln -s ${ccache} /usr/local/bin/clang++`);
+    }
     core.info("Cccache config:");
     await execBash("ccache -p");
   } else {


### PR DESCRIPTION
It is an optional flag, so it should not break existing usages.

**Why this PR work?**

References:
- https://ccache.dev/manual/4.8.3.html#_run_modes
- https://github.com/ccache/ccache/blob/master/doc/INSTALL.md#installation
- https://reactnative.dev/docs/build-speed#local-caches

These links above all point out that we can use a symlink to let ccache override the default compilers.