### PR TITLE
fix: early exit process so node doesn't want for hanging promises

### DIFF
--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -59582,7 +59582,7 @@ async function getVerbosity(verbositySetting) {
 function getExecBashOutput(cmd) {
     return _actions_exec__WEBPACK_IMPORTED_MODULE_2__.getExecOutput("bash", ["-xc", cmd], { silent: true });
 }
-async function run() {
+async function run(earlyExit) {
     try {
         const ccacheVariant = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getState("ccacheVariant");
         const primaryKey = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getState("primaryKey");
@@ -59620,9 +59620,18 @@ async function run() {
         // A failure to save cache shouldn't prevent the entire CI run from
         // failing, so do not call setFailed() here.
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.warning(`Saving cache failed: ${error}`);
+        // Early exit process so node doesn't want for hanging promises
+        if (earlyExit) {
+            process.exit(-1);
+        }
+    }
+    // Since we are not using http requests after this
+    // we can safely exit early
+    if (earlyExit) {
+        process.exit(0);
     }
 }
-run();
+run(true);
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (run);
 
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@actions/io": "^1.1.3"
       },
       "devDependencies": {
+        "@types/node": "^20.11.10",
         "@vercel/ncc": "^0.38.1",
         "typescript": "^5.3.3"
       }
@@ -305,9 +306,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.14.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
-      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
+      "version": "20.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
+      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -531,6 +535,11 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/uuid": {
       "version": "3.4.0",
@@ -843,9 +852,12 @@
       "integrity": "sha512-IgMK9i3sFGNUqPMbjABm0G26g0QCKCUBfglhQ7rQq6WcxbKfEHRcmwsoER4hZcuYqJgkYn2OeuoJIv7Jsftp7g=="
     },
     "@types/node": {
-      "version": "18.14.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
-      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
+      "version": "20.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
+      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -1011,6 +1023,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@actions/io": "^1.1.3"
   },
   "devDependencies": {
+    "@types/node": "^20.11.10",
     "@vercel/ncc": "^0.38.1",
     "typescript": "^5.3.3"
   },

--- a/src/save.ts
+++ b/src/save.ts
@@ -35,7 +35,7 @@ function getExecBashOutput(cmd : string) : Promise<exec.ExecOutput> {
   return exec.getExecOutput("bash", ["-xc", cmd], {silent: true});
 }
 
-async function run() : Promise<void> {
+async function run(earlyExit : boolean | undefined) : Promise<void> {
   try {
     const ccacheVariant = core.getState("ccacheVariant");
     const primaryKey = core.getState("primaryKey");
@@ -75,9 +75,20 @@ async function run() : Promise<void> {
     // A failure to save cache shouldn't prevent the entire CI run from
     // failing, so do not call setFailed() here.
     core.warning(`Saving cache failed: ${error}`);
+
+    // Early exit process so node doesn't want for hanging promises
+    if (earlyExit) {
+      process.exit(-1);
+    }
+  }
+
+  // Since we are not using http requests after this
+  // we can safely exit early
+  if (earlyExit) {
+    process.exit(0);
   }
 }
 
-run();
+run(true);
 
 export default run;


### PR DESCRIPTION
### Issue

fixes: #181 

### Proposed Changes

Since Node waits for hanging http requests we early exit by calling `process.exit`. This doesn't affect the existing API but we can specify optional parameter `earlyExit` that would apply this fix.

This is related to https://github.com/nodejs/node/issues/47228