### PR TITLE
adjust key computation to avoid trailing `-`

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -59588,9 +59588,8 @@ async function restore(ccacheVariant) {
         // https://github.com/actions/cache/blob/73cb7e04054996a98d39095c0b7821a73fb5b3ea/src/utils/actionUtils.ts#L56
         restoreKeys: core.getInput("restore-keys").split("\n").map(s => s.trim()).filter(x => x !== "")
     };
-    const keyPrefix = ccacheVariant + "-";
-    const primaryKey = inputs.primaryKey ? keyPrefix + inputs.primaryKey + "-" : keyPrefix;
-    const restoreKeys = inputs.restoreKeys.map(k => keyPrefix + k + "-");
+    const primaryKey = inputs.primaryKey ? ccacheVariant + "-" + inputs.primaryKey : ccacheVariant;
+    const restoreKeys = inputs.restoreKeys.map(k => ccacheVariant + "-" + k);
     const paths = [`.${ccacheVariant}`];
     core.saveState("primaryKey", primaryKey);
     const shouldRestore = core.getBooleanInput("restore");

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -59606,7 +59606,7 @@ async function run() {
         else {
             let saveKey = primaryKey;
             if (_actions_core__WEBPACK_IMPORTED_MODULE_0__.getState("appendTimestamp") == "true") {
-                saveKey += new Date().toISOString();
+                saveKey += `-${new Date().toISOString()}`;
             }
             else {
                 _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug("Not appending timestamp because 'append-timestamp' is not set to 'true'.");

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -19,9 +19,8 @@ async function restore(ccacheVariant : string) : Promise<void> {
     restoreKeys: core.getInput("restore-keys").split("\n").map(s => s.trim()).filter(x => x !== "")
   };
 
-  const keyPrefix = ccacheVariant + "-";
-  const primaryKey = inputs.primaryKey ? keyPrefix + inputs.primaryKey + "-" : keyPrefix;
-  const restoreKeys = inputs.restoreKeys.map(k => keyPrefix + k + "-")
+  const primaryKey = inputs.primaryKey ? ccacheVariant + "-" + inputs.primaryKey : ccacheVariant;
+  const restoreKeys = inputs.restoreKeys.map(k => ccacheVariant + "-" + k)
   const paths = [`.${ccacheVariant}`];
 
   core.saveState("primaryKey", primaryKey);

--- a/src/save.ts
+++ b/src/save.ts
@@ -62,7 +62,7 @@ async function run() : Promise<void> {
     } else {
       let saveKey = primaryKey;
       if (core.getState("appendTimestamp") == "true") {
-        saveKey += new Date().toISOString();
+        saveKey += `-${new Date().toISOString()}`;
       } else {
         core.debug("Not appending timestamp because 'append-timestamp' is not set to 'true'.");
       }


### PR DESCRIPTION
The `-` suffix was being applied unconditionally resulting in a hanging `-` suffix if no timestamp was used. Adjust the key computation to remove the trailing `-` if no timestamp is used.