### PR TITLE
Make ccache-action respect environment variables

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
             sccache -V
             sccache -s
             # sccache -s | grep -E 'Max cache size.+10 MiB'
-            sccache -s | grep -E "Cache location.+${SCCACHE_DIR:-ccache-action[\\/]\.sccache}"
+            sccache -s | grep -E "Cache location.+${SCCACHE_DIR:-ccache-action[\\/]+\.sccache}"
           else
             which ccache
             ccache -V

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
             sccache -V
             sccache -s
             # sccache -s | grep -E 'Max cache size.+10 MiB'
-            sccache -s | grep -E 'Cache location.+ccache-action/\.sccache'
+            sccache -s | grep -E "Cache location.+${SCCACHE_DIR:-ccache-action[\\/]\.sccache}"
           else
             which ccache
             ccache -V

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,0 +1,11 @@
+import path from "path";
+
+export function cacheDir(ccacheVariant: string): string {
+    const ghWorkSpace = process.env.GITHUB_WORKSPACE || "unreachable, make ncc happy";
+    if (ccacheVariant === "ccache") {
+        return process.env.CCACHE_DIR || path.join(ghWorkSpace, ".ccache");
+    } else if (ccacheVariant === "sccache") {
+        return process.env.SCCACHE_DIR || path.join(ghWorkSpace, ".sccache");
+    }
+    throw Error("Unknown ccache variant: " + ccacheVariant);
+}

--- a/src/save.ts
+++ b/src/save.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 import * as cache from "@actions/cache";
 import * as exec from "@actions/exec";
+import { cacheDir } from "./common";
 
 async function ccacheIsEmpty(ccacheVariant : string, ccacheKnowsVerbosityFlag : boolean) : Promise<boolean> {
   if (ccacheVariant === "ccache") {
@@ -51,7 +52,7 @@ async function run(earlyExit : boolean | undefined) : Promise<void> {
     const verbosity = ccacheKnowsVerbosityFlag ? await getVerbosity(core.getInput("verbose")) : '';
     await exec.exec(`${ccacheVariant} -s${verbosity}`);
     core.endGroup();
-    
+
     if (core.getState("shouldSave") !== "true") {
       core.info("Not saving cache because 'save' is set to 'false'.");
       return;
@@ -66,8 +67,9 @@ async function run(earlyExit : boolean | undefined) : Promise<void> {
       } else {
         core.debug("Not appending timestamp because 'append-timestamp' is not set to 'true'.");
       }
-      const paths = [`.${ccacheVariant}`];
-    
+
+      const paths = [cacheDir(ccacheVariant)];
+
       core.info(`Save cache using key "${saveKey}".`);
       await cache.saveCache(paths, saveKey);
     }


### PR DESCRIPTION
Currently, if environment variables are set for CCACHE_DIR or SCCACHE_DIR then this action will ignore them and hardcode its own.

This is a problem if CCACHE_DIR is set for example in a docker file environment which is very hard to eliminate 

Fixes #96 

I think this is a better solution than #165 as that one still suffers from an invalid operation if either of the environment variables are set.