### PR TITLE
Evict old files from the cache prior to saving

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        evict: [true, false]
+        evict: ['job', '30s', '']
     steps:
       - uses: actions/checkout@v4
       - name: Run ccache-action

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,3 +240,15 @@ jobs:
           else
             ls -l $(which gcc) | grep -v $(which ccache)
           fi
+
+  test_option_evict:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        evict: [true, false]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ccache-action
+        uses: ./
+        with:
+          evict-old-files: ${{ matrix.evict }}

--- a/__tests__/common.test.ts
+++ b/__tests__/common.test.ts
@@ -1,7 +1,20 @@
 import * as common  from '../src/common';
-
+import * as core from "@actions/core";
 
 describe('ccache common', () => {
+    test('get duration of job in seconds', () => {
+        const stateMock = jest.spyOn(core, "getState");
+        const expectedAgeInSeconds = 1234;
+        const startTimeMs = 1734258917128;
+        const endTimeMs = startTimeMs + expectedAgeInSeconds * 1000;
+        stateMock.mockImplementationOnce(() => startTimeMs.toString());
+        jest.useFakeTimers().setSystemTime(new Date(endTimeMs));
+
+        const age = common.getJobDurationInSeconds();
+        expect(stateMock).toHaveBeenCalledWith("startTimestamp");
+        expect(age).toBe(expectedAgeInSeconds);
+    });
+
     test('parse version string from ccache output', () => {
         const ccacheOutput = `ccache version 4.10.2
 Features: avx2 file-storage http-storage redis+unix-storage redis-storage

--- a/__tests__/common.test.ts
+++ b/__tests__/common.test.ts
@@ -2,6 +2,26 @@ import * as common  from '../src/common';
 import * as core from "@actions/core";
 
 describe('ccache common', () => {
+    test('parse evict age parameter in seconds', () => {
+        const age = '42s';
+        const [time, unit] = common.parseEvictAgeParameter(age);
+        expect(time).toEqual(42);
+        expect(unit).toEqual(common.AgeUnit.Seconds);
+    });
+
+    test('parse evict age parameter in days', () => {
+        const age = '28d';
+        const [time, unit] = common.parseEvictAgeParameter(age);
+        expect(time).toEqual(28);
+        expect(unit).toEqual(common.AgeUnit.Days);
+    });
+
+    test('parse evict age parameter - job', () => {
+        const age = 'job';
+        const [, unit] = common.parseEvictAgeParameter(age);
+        expect(unit).toEqual(common.AgeUnit.Job);
+    });
+
     test('get duration of job in seconds', () => {
         const stateMock = jest.spyOn(core, "getState");
         const expectedAgeInSeconds = 1234;

--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -1,0 +1,14 @@
+import * as save  from '../src/save';
+import * as exec from "@actions/exec";
+
+jest.mock("@actions/exec");
+
+describe('ccache save', () => {
+    test('evict old files from the cache', async () => {
+        const proc = jest.spyOn(exec, "exec");
+
+        const ageInSeconds = 42;
+        await save.evictOldFiles(ageInSeconds);
+        expect(proc).toHaveBeenCalledWith(`ccache --evict-older-than ${ageInSeconds}s`);
+    });
+});

--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -1,14 +1,23 @@
+import {AgeUnit} from "../src/common";
 import * as save  from '../src/save';
 import * as exec from "@actions/exec";
 
 jest.mock("@actions/exec");
 
 describe('ccache save', () => {
-    test('evict old files from the cache', async () => {
+    test('evict old files from the cache by age in seconds', async () => {
         const proc = jest.spyOn(exec, "exec");
 
         const ageInSeconds = 42;
-        await save.evictOldFiles(ageInSeconds);
+        await save.evictOldFiles(ageInSeconds, AgeUnit.Seconds);
         expect(proc).toHaveBeenCalledWith(`ccache --evict-older-than ${ageInSeconds}s`);
+    });
+
+    test('evict old files from the cache by age in days', async () => {
+        const proc = jest.spyOn(exec, "exec");
+
+        const ageInDays = 3;
+        await save.evictOldFiles(ageInDays, AgeUnit.Days);
+        expect(proc).toHaveBeenCalledWith(`ccache --evict-older-than ${ageInDays}d`);
     });
 });

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: "Publish stats as part of the job summary. Set to the title of the job summary section, or to the 
      empty string to disable this feature. Requires CCache 4.10+"
     default: 'CCache Statistics'
+  evict-old-files:
+    description: "Evict any files not used in the current job run from the cache. Corresponds to the ccache 
+      --evict-older-than AGE option, where AGE is the number of seconds since the job started."
+    default: true
 runs:
   using: "node20"
   main: "dist/restore/index.js"

--- a/action.yml
+++ b/action.yml
@@ -37,9 +37,10 @@ inputs:
      empty string to disable this feature. Requires CCache 4.10+"
     default: 'CCache Statistics'
   evict-old-files:
-    description: "Evict any files not used in the current job run from the cache. Corresponds to the ccache 
-      --evict-older-than AGE option, where AGE is the number of seconds since the job started."
-    default: true
+    description: "Corresponds to the ccache --evict-older-than AGE option, where AGE is the number of seconds or days
+      followed by the 's' or 'd' suffix respectively. Also supports the special value 'job' which represents the time
+      since the job started, which evicts all cache files that were not touched during the job run."
+    default: ''
 runs:
   using: "node20"
   main: "dist/restore/index.js"

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -58831,9 +58831,28 @@ var cache = __nccwpck_require__(5116);
 ;// CONCATENATED MODULE: ./src/common.ts
 
 
+var AgeUnit;
+(function (AgeUnit) {
+    AgeUnit["Seconds"] = "s";
+    AgeUnit["Days"] = "d";
+    AgeUnit["Job"] = "job";
+})(AgeUnit || (AgeUnit = {}));
 function getJobDurationInSeconds() {
     const startTime = Number.parseInt(core.getState("startTimestamp"));
     return Math.floor((Date.now() - startTime) * 0.001);
+}
+function parseEvictAgeParameter(age) {
+    const expr = /([0-9]+)([sd])|job/;
+    const result = age.match(expr);
+    if (result) {
+        if (result[0] !== "job") {
+            return [Number.parseInt(result[1]), result[2]];
+        }
+        else {
+            return [null, AgeUnit.Job];
+        }
+    }
+    throw new Error(`age parameter ${age} was not valid`);
 }
 /**
  * Parse the output of ccache --version to extract the semantic version components
@@ -59030,7 +59049,7 @@ async function runInner() {
     const ccacheVariant = lib_core.getInput("variant");
     lib_core.saveState("startTimestamp", Date.now());
     lib_core.saveState("ccacheVariant", ccacheVariant);
-    lib_core.saveState("evictOldFiles", lib_core.getBooleanInput("evict-old-files"));
+    lib_core.saveState("evictOldFiles", lib_core.getInput("evict-old-files"));
     lib_core.saveState("shouldSave", lib_core.getBooleanInput("save"));
     lib_core.saveState("appendTimestamp", lib_core.getBooleanInput("append-timestamp"));
     let ccachePath = await io.which(ccacheVariant);

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,7 +1,13 @@
 import path from "path";
 import {SummaryTableRow} from "@actions/core/lib/summary";
+import * as core from "@actions/core";
 
 type Version = [number,number,number];
+
+export function getJobDurationInSeconds() : number  {
+    const startTime = Number.parseInt(core.getState("startTimestamp"));
+    return Math.floor((Date.now() - startTime) * 0.001);
+}
 
 /**
  * Parse the output of ccache --version to extract the semantic version components

--- a/src/common.ts
+++ b/src/common.ts
@@ -4,9 +4,29 @@ import * as core from "@actions/core";
 
 type Version = [number,number,number];
 
+export enum AgeUnit {
+    Seconds = "s",
+    Days = "d",
+    Job = "job"
+}
+
 export function getJobDurationInSeconds() : number  {
     const startTime = Number.parseInt(core.getState("startTimestamp"));
     return Math.floor((Date.now() - startTime) * 0.001);
+}
+
+export function parseEvictAgeParameter(age: string): [number | null, AgeUnit] {
+    const expr = /([0-9]+)([sd])|job/
+    const result = age.match(expr);
+    if (result) {
+        if (result[0] !== "job") {
+            return [Number.parseInt(result[1]), result[2] as AgeUnit];
+        } else {
+            return [null, AgeUnit.Job];
+        }
+    }
+
+    throw new Error(`age parameter ${age} was not valid`);
 }
 
 /**

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -182,6 +182,7 @@ function checkSha256Sum (path : string, expectedSha256 : string) {
 
 async function runInner() : Promise<void> {
   const ccacheVariant = core.getInput("variant");
+  core.saveState("startTimestamp", Date.now());
   core.saveState("ccacheVariant", ccacheVariant);
   core.saveState("shouldSave", core.getBooleanInput("save"));
   core.saveState("appendTimestamp", core.getBooleanInput("append-timestamp"));

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -184,6 +184,7 @@ async function runInner() : Promise<void> {
   const ccacheVariant = core.getInput("variant");
   core.saveState("startTimestamp", Date.now());
   core.saveState("ccacheVariant", ccacheVariant);
+  core.saveState("evictOldFiles", core.getBooleanInput("evict-old-files"));
   core.saveState("shouldSave", core.getBooleanInput("save"));
   core.saveState("appendTimestamp", core.getBooleanInput("append-timestamp"));
   let ccachePath = await io.which(ccacheVariant);

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -184,7 +184,7 @@ async function runInner() : Promise<void> {
   const ccacheVariant = core.getInput("variant");
   core.saveState("startTimestamp", Date.now());
   core.saveState("ccacheVariant", ccacheVariant);
-  core.saveState("evictOldFiles", core.getBooleanInput("evict-old-files"));
+  core.saveState("evictOldFiles", core.getInput("evict-old-files"));
   core.saveState("shouldSave", core.getBooleanInput("save"));
   core.saveState("appendTimestamp", core.getBooleanInput("append-timestamp"));
   let ccachePath = await io.which(ccacheVariant);


### PR DESCRIPTION
uses the `--evict-older-than` option to evict any files from the cache that were not used during the job run. This prevents the cache from growing indefinitely as otherwise old files from previously restored caches are never deleted.

For a test I performed the following - 

1. [Built CMake 3.30.6](https://github.com/planetmarshall/ccache-action/actions/runs/12339373031)
    * `evictOldFiles=true` - cache Size 39Mb
    *  `evictOldFiles=false` - cache Size 39Mb
2. Then [Built CMake 3.31.2](https://github.com/planetmarshall/ccache-action/actions/runs/12339423977/attempts/1), reusing the cache from 1. Minimal cache hits in both cases due to change in sources.
    * `evictOldFiles=true` - cache Size 39Mb
    *  `evictOldFiles=false` - cache Size 78Mb
3. Then [Built CMake 3.31.2](https://github.com/planetmarshall/ccache-action/actions/runs/12339423977) again
    * `evictOldFiles=true` - cache Size 39Mb - Cache hits 100%
    *  `evictOldFiles=false` - cache Size 78Mb - Cache hits 100%

