### PR TITLE
Use sudo (if available) when installing sccache

### DIFF
--- a/src/restore.ts
+++ b/src/restore.ts
@@ -133,7 +133,7 @@ async function execShell(cmd : string) {
 }
 
 async function execShellSudo(cmd : string) {
-  await execShell("$(which sudo) " + cmd);
+  await execShell("$(which sudo) sh -xc '" + cmd + "'");
 }
 
 async function installCcacheFromGitHub(version : string, artifactName : string, binSha256 : string, binDir : string, binName : string) : Promise<void> {
@@ -167,7 +167,7 @@ async function downloadAndExtract (url : string, srcFile : string, dstFile : str
     fs.copyFileSync(path.join(tmp, srcFile), dstFile);
     fs.rmSync(tmp, { recursive: true });
   } else {
-    await execShell(`curl -L '${url}' | tar xzf - -O --wildcards '${srcFile}' > '${dstFile}'`);
+    await execShellSudo(`curl -L '${url}' | tar xzf - -O --wildcards '${srcFile}' > '${dstFile}'`);
   }
 }
 


### PR DESCRIPTION
When running this action inside a container as a non-root user, installing sccache will typically fail due to the non-root user not having write permissions to /usr/local/bin. This patch fixes this by using sudo for downloading/installing sccache along with some modifications to executeShellSudo so that it will execute the entire command as expected.