### PR TITLE
support Ubuntu arm64 runners with sccache variant

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         shell: [bash]
         variant: [sccache, ccache]
         include:
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         shell: [bash]
         variant: [sccache, ccache]
         include:
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         shell: [bash]
         variant: [sccache, ccache]
         include:
@@ -150,7 +150,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         shell: [bash]
         variant: [sccache, ccache]
         include:

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -68150,7 +68150,21 @@ async function installSccacheMac() {
     await execShell("brew install sccache");
 }
 async function installSccacheLinux() {
-    await installSccacheFromGitHub("v0.7.6", "x86_64-unknown-linux-musl", "8c2bb0805983a6fe334fa8b5c26db2c5fc3a7fc3dbf51522a08f2e4c50e4fbe7", "/usr/local/bin/", "sccache");
+    let packageName;
+    let sha256;
+    switch (external_process_namespaceObject.arch) {
+        case "x64":
+            packageName = "x86_64-unknown-linux-musl";
+            sha256 = "8c2bb0805983a6fe334fa8b5c26db2c5fc3a7fc3dbf51522a08f2e4c50e4fbe7";
+            break;
+        case "arm64":
+            packageName = "aarch64-unknown-linux-musl";
+            sha256 = "d4773c9a6716b70ecdf646c1ee018e1b5be71bed0af5c3d82e5c595833744dbf";
+            break;
+        default:
+            throw new Error(`Unsupported architecture: ${external_process_namespaceObject.arch}`);
+    }
+    await installSccacheFromGitHub("v0.7.6", packageName, sha256, "/usr/local/bin/", "sccache");
 }
 async function installSccacheWindows() {
     await installSccacheFromGitHub("v0.7.6", "x86_64-pc-windows-msvc", "48e88be2ba87dca8d74364f045894ec214b6c850e65e61ab44e5071055c9e6d3", 

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -108,10 +108,24 @@ async function installSccacheMac() : Promise<void> {
 }
 
 async function installSccacheLinux() : Promise<void> {
+  let packageName: string;
+  let sha256: string;
+  switch (process.arch) {
+    case "x64":
+      packageName = "x86_64-unknown-linux-musl";
+      sha256 = "8c2bb0805983a6fe334fa8b5c26db2c5fc3a7fc3dbf51522a08f2e4c50e4fbe7";
+      break;
+    case "arm64":
+      packageName = "aarch64-unknown-linux-musl";
+      sha256 = "d4773c9a6716b70ecdf646c1ee018e1b5be71bed0af5c3d82e5c595833744dbf";
+      break;
+    default:
+      throw new Error(`Unsupported architecture: ${process.arch}`);
+  }
   await installSccacheFromGitHub(
     "v0.7.6",
-    "x86_64-unknown-linux-musl",
-    "8c2bb0805983a6fe334fa8b5c26db2c5fc3a7fc3dbf51522a08f2e4c50e4fbe7",
+    packageName,
+    sha256,
     "/usr/local/bin/",
     "sccache"
   );


### PR DESCRIPTION
## Purpose
Enable the `sccache` variant of  `ccache-action` to run on GitHub Ubuntu arm64 runners.

## Background
GitHub now supports a public preview of Ubuntu on arm64 runners, [announced last week](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/). The new runners can be used by anyone on any public repo.

The current implementation of `cccache-action` unconditionally downloads the Linux x86_64 `sccache` package when using the `sccache` variant. This package is incompatible with the arm runners.

NOTE: The `ccache` variant already works correctly on the arm runners because it installs `ccache` via the system's package manager.

## Validation
Updated test workflow to run tests on `ubuntu-24.04-arm` and verify they pass [here](https://github.com/andrurogerz/ccache-action/actions/runs/12876789381).