### PR TITLE
set cache to readonly if skipping save

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -68103,6 +68103,9 @@ async function configure(ccacheVariant, platform) {
         await execShell(`ccache --set-config=cache_dir='${cacheDir(ccacheVariant)}'`);
         await execShell(`ccache --set-config=max_size='${maxSize}'`);
         await execShell(`ccache --set-config=compression=true`);
+        if (!lib_core.getBooleanInput("save")) {
+            await execShell(`ccache --set-config=read_only=true`);
+        }
         if (platform === "darwin") {
             await execShell(`ccache --set-config=compiler_check=content`);
         }

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -53,6 +53,9 @@ async function configure(ccacheVariant : string, platform : string) : Promise<vo
     await execShell(`ccache --set-config=cache_dir='${cacheDir(ccacheVariant)}'`);
     await execShell(`ccache --set-config=max_size='${maxSize}'`);
     await execShell(`ccache --set-config=compression=true`);
+    if (!core.getBooleanInput("save")) {
+      await execShell(`ccache --set-config=read_only=true`);
+    }
     if (platform === "darwin") {
       await execShell(`ccache --set-config=compiler_check=content`);
     }


### PR DESCRIPTION
If we aren't saving the cache we can get a small performance improvement by not writing new cache files during a build.