### PR TITLE
Fix installing on windows/ARM64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest, windows-11-arm]
         shell: [bash]
         variant: [sccache, ccache]
         include:
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest, windows-11-arm]
         shell: [bash]
         variant: [sccache, ccache]
         include:
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest, windows-11-arm]
         shell: [bash]
         variant: [sccache, ccache]
         include:
@@ -150,7 +150,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest, windows-11-arm]
         shell: [bash]
         variant: [sccache, ccache]
         include:

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -65403,6 +65403,7 @@ async function installCcacheFromGitHub(version, artifactName, binSha256, binDir,
     const binPath = external_path_default().join(binDir, binName);
     await downloadAndExtract(url, external_path_default().join(archiveName, binName), binPath);
     checkSha256Sum(binPath, binSha256);
+    lib_core.addPath(binDir);
 }
 async function installSccacheFromGitHub(version, artifactName, binSha256, binDir, binName) {
     const archiveName = `sccache-${version}-${artifactName}`;

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -65414,15 +65414,15 @@ async function installSccacheFromGitHub(version, artifactName, binSha256, binDir
     await execShell(`chmod +x '${binPath}'`);
 }
 async function downloadAndExtract(url, srcFile, dstFile) {
+    const dstDir = external_path_default().dirname(dstFile);
+    if (!external_fs_default().existsSync(dstDir)) {
+        external_fs_default().mkdirSync(dstDir, { recursive: true });
+    }
     if (url.endsWith(".zip")) {
         const tmp = external_fs_default().mkdtempSync(external_path_default().join(external_os_default().tmpdir(), ""));
         const zipName = external_path_default().join(tmp, "dl.zip");
         await execShell(`curl -L '${url}' -o '${zipName}'`);
         await execShell(`unzip '${zipName}' -d '${tmp}'`);
-        const dstDir = external_path_default().dirname(dstFile);
-        if (!external_fs_default().existsSync(dstDir)) {
-            external_fs_default().mkdirSync(dstDir, { recursive: true });
-        }
         external_fs_default().copyFileSync(external_path_default().join(tmp, srcFile), dstFile);
         external_fs_default().rmSync(tmp, { recursive: true });
     }

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -174,15 +174,15 @@ async function installSccacheFromGitHub(version : string, artifactName : string,
 }
 
 async function downloadAndExtract (url : string, srcFile : string, dstFile : string) {
+  const dstDir = path.dirname(dstFile);
+  if (!fs.existsSync(dstDir)) {
+    fs.mkdirSync(dstDir, { recursive: true });
+  }
   if (url.endsWith(".zip")) {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), ""));
     const zipName = path.join(tmp, "dl.zip");
     await execShell(`curl -L '${url}' -o '${zipName}'`);
     await execShell(`unzip '${zipName}' -d '${tmp}'`);
-    const dstDir = path.dirname(dstFile);
-    if (!fs.existsSync(dstDir)) {
-      fs.mkdirSync(dstDir, { recursive: true });
-    }
     fs.copyFileSync(path.join(tmp, srcFile), dstFile);
     fs.rmSync(tmp, { recursive: true });
   } else {

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -161,6 +161,7 @@ async function installCcacheFromGitHub(version : string, artifactName : string, 
   const binPath = path.join(binDir, binName);
   await downloadAndExtract(url, path.join(archiveName, binName), binPath);
   checkSha256Sum(binPath, binSha256);
+  core.addPath(binDir);
 }
 
 async function installSccacheFromGitHub(version : string, artifactName : string, binSha256 : string, binDir : string, binName : string) : Promise<void> {


### PR DESCRIPTION
The main root issue is that the directory `${process.env.USERPROFILE}\\.cargo\\bin` doesn't exist beforehand, and isn't included in `$PATH`. Due to minor inconsistencies between the ccache/sccache cases, this issue had slightly different symptoms.

Fixes #317.