### PR TITLE
Use 'MB' in max-size default instead of 'M'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
   max-size:
     description: "Max size of the cache"
-    default: "500M"
+    default: "500MB"
   verbose:
     description: "Verbosity level: 0 (default), 1 or 2. Ignore for sccache."
     default: 0


### PR DESCRIPTION
"M" shouldn't cause any errors, but just to be consistent with officially documented supported suffixes in https://ccache.dev/manual/4.12.html

<img width="1013" height="134" alt="image" src="https://github.com/user-attachments/assets/06d49abb-cf33-4d5e-b62c-02b588b5c33d" />
