### PR TITLE
refactor: add Windows ARM and macOS binaries, use a single Package class, deduplicate some common install code

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     default: false
     required: false
   job-summary:
-    description: "Publish stats as part of the job summary. Set to the title of the job summary section, or to the 
+    description: "Publish stats as part of the job summary. Set to the title of the job summary section, or to the
      empty string to disable this feature. Requires CCache 4.10+"
     default: 'CCache Statistics'
   evict-old-files:
@@ -46,6 +46,13 @@ inputs:
       ccache-action in a container or from `act`. Disabling this might speed up the action execution."
     default: false
     required: false
+  install:
+    description: "Whether or not to install ccache automatically. Options:
+      - yes: forcefully install through the package manager if available, or fall back to a binary
+      - binary: forcefully install a binary package
+      - detect (default): install ccache if not available
+      - no: do not attempt to install ccache"
+    default: detect
 runs:
   using: "node20"
   main: "dist/restore/index.js"

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -38969,7 +38969,18 @@ __nccwpck_require__.r(__webpack_exports__);
 
 // EXPORTS
 __nccwpck_require__.d(__webpack_exports__, {
-  "default": () => (/* binding */ src_restore)
+  ARCH: () => (/* binding */ ARCH),
+  DARWIN: () => (/* binding */ DARWIN),
+  INSTALL_METHOD: () => (/* binding */ INSTALL_METHOD),
+  LINUX: () => (/* binding */ LINUX),
+  PLATFORM: () => (/* binding */ PLATFORM),
+  Package: () => (/* binding */ Package),
+  VARIANT: () => (/* binding */ VARIANT),
+  WINDOWS: () => (/* binding */ WINDOWS),
+  "default": () => (/* binding */ src_restore),
+  selectMethod: () => (/* binding */ selectMethod),
+  selectPackage: () => (/* binding */ selectPackage),
+  selectVariant: () => (/* binding */ selectVariant)
 });
 
 // NAMESPACE OBJECT: ./node_modules/@azure/storage-blob/dist/esm/generated/src/models/mappers.js
@@ -85173,6 +85184,326 @@ function cacheDir(ccacheVariant) {
 
 
 
+var VARIANT;
+(function (VARIANT) {
+    VARIANT["SCCACHE"] = "sccache";
+    VARIANT["CCACHE"] = "ccache";
+})(VARIANT || (VARIANT = {}));
+var ARCH;
+(function (ARCH) {
+    ARCH["X86_64"] = "x86_64";
+    ARCH["AARCH64"] = "aarch64";
+})(ARCH || (ARCH = {}));
+var PLATFORM;
+(function (PLATFORM) {
+    PLATFORM["LINUX"] = "linux";
+    PLATFORM["WINDOWS"] = "windows";
+    PLATFORM["DARWIN"] = "darwin";
+})(PLATFORM || (PLATFORM = {}));
+var INSTALL_METHOD;
+(function (INSTALL_METHOD) {
+    INSTALL_METHOD["YES"] = "yes";
+    INSTALL_METHOD["BINARY"] = "binary";
+    INSTALL_METHOD["DETECT"] = "detect";
+    INSTALL_METHOD["NO"] = "no";
+})(INSTALL_METHOD || (INSTALL_METHOD = {}));
+class Package {
+    constructor(variant, arch, platform, sha256, version) {
+        this.variant = variant;
+        this.arch = arch;
+        this.platform = platform;
+        this.sha256 = sha256;
+        this.version = version;
+    }
+    /**
+     * Get the name of this package.
+     * @returns The name of the package used to determine the artifact name and extracted directory.
+     */
+    packageName() {
+        const v = this.version;
+        if (this.variant === VARIANT.CCACHE) {
+            // ccache darwin is a universal binary
+            if (this.platform === PLATFORM.DARWIN) {
+                return `ccache-${v}-darwin`;
+            }
+            return `ccache-${v}-${this.platform}-${this.arch}`;
+        }
+        let suffix;
+        switch (this.platform) {
+            case PLATFORM.LINUX:
+                suffix = "unknown-linux-musl";
+                break;
+            case PLATFORM.WINDOWS:
+                suffix = "pc-windows-msvc";
+                break;
+            case PLATFORM.DARWIN:
+                suffix = "apple-darwin";
+                break;
+        }
+        return `sccache-${v}-${this.arch}-${suffix}`;
+    }
+    /**
+     * Get the artifact name of the package.
+     * @returns The fully-qualified artifact name used to download the package.
+     */
+    downloadName() {
+        const base = this.packageName();
+        // sccache is just tar.gz
+        let extension = "tar.gz";
+        if (this.variant === VARIANT.CCACHE) {
+            switch (this.platform) {
+                case PLATFORM.LINUX:
+                    extension = "tar.xz";
+                    break;
+                case PLATFORM.WINDOWS:
+                    extension = "zip";
+                    break;
+                case PLATFORM.DARWIN:
+                    break;
+            }
+        }
+        return `${base}.${extension}`;
+    }
+    /**
+     * Get the URL to download this package's artifact
+     * @returns The fully-qualified URL to download this package's artifact.
+     */
+    downloadUrl() {
+        const artifact = this.downloadName();
+        const repo = this.variant === VARIANT.CCACHE
+            ? "ccache/ccache"
+            : "mozilla/sccache";
+        // ccache is a little special sometimes :)
+        const version = this.variant === VARIANT.CCACHE ? `v${this.version}` : `${this.version}`;
+        return `https://github.com/${repo}/releases/download/${version}/${artifact}`;
+    }
+    async downloadAndExtract(srcFile, dstFile) {
+        const dstDir = external_path_default().dirname(dstFile);
+        if (!external_fs_default().existsSync(dstDir)) {
+            external_fs_default().mkdirSync(dstDir, { recursive: true });
+        }
+        const url = this.downloadUrl();
+        const tmp = external_fs_default().mkdtempSync(external_path_default().join(external_os_default().tmpdir(), "ccache"));
+        const dlName = external_path_default().join(tmp, this.downloadName());
+        await execShell(`curl -L '${url}' -o '${dlName}'`);
+        if (url.endsWith(".zip")) {
+            await execShell(`unzip '${dlName}' -d '${tmp}'`);
+            external_fs_default().copyFileSync(external_path_default().join(tmp, srcFile), dstFile);
+            external_fs_default().rmSync(tmp, { recursive: true });
+        }
+        else {
+            // windows is a little special :)
+            if (this.platform === PLATFORM.WINDOWS) {
+                const winName = dlName.replaceAll('\\', '/');
+                await execShell(`tar xf "$(cygpath -u ${winName})" -O '${srcFile}' > '${dstFile}'`);
+            }
+            else
+                await execShell(`tar xf '${dlName}' -O '${srcFile}' > '${dstFile}'`);
+        }
+    }
+    /**
+     * Install the package.
+     */
+    async installBinary() {
+        const isWindows = this.platform === PLATFORM.WINDOWS;
+        // TODO: evaluate
+        const binDir = this.platform === PLATFORM.WINDOWS
+            ? external_path_default().join(external_process_namespaceObject.env.USERPROFILE, ".cargo", "bin")
+            : "/usr/local/bin";
+        // Also prepend install path to PATH var
+        // To prevent pre-existing install potentially clobbering this one
+        addPath(binDir);
+        const binName = isWindows
+            ? `${this.variant}.exe`
+            : this.variant;
+        const binPath = external_path_default().join(binDir, binName);
+        await this.downloadAndExtract(`${this.packageName()}/${binName}`, binPath);
+        // TODO: ccache provides minisig and sccache provides sha256 downloads,
+        // maybe verify w/ that?
+        checkSha256Sum(binPath, this.sha256);
+        addPath(binDir);
+        await execShell(`chmod +x '${binPath}'`);
+    }
+    /**
+     * Attempt to install this package from the package manager.
+     * @returns Whether or not it was successfully installed.
+     */
+    async installPackageManager() {
+        const shouldUpdate = getBooleanInput("update-package-index");
+        const pkg = this.variant;
+        let updateCmd;
+        let installCmd;
+        let needSudo = false;
+        // some distros don't have sccache
+        let hasSccache = true;
+        switch (this.platform) {
+            case PLATFORM.DARWIN:
+                updateCmd = "brew update";
+                installCmd = "brew install";
+                break;
+            case PLATFORM.LINUX:
+                if (await which("apt-get")) {
+                    updateCmd = "apt-get update";
+                    installCmd = "apt-get install -y";
+                    hasSccache = false;
+                    needSudo = true;
+                }
+                else if (await which("apk")) {
+                    updateCmd = "apk update";
+                    installCmd = "apk add";
+                    hasSccache = false;
+                }
+                else if (await which("dnf")) {
+                    updateCmd = "dnf check-update";
+                    installCmd = "dnf install -y";
+                    // ccache needs epel repo
+                    await execShell(`${installCmd} epel-release`);
+                }
+                else if (await which("pacman")) {
+                    // arch frequently upgrades glibc and such
+                    // partial updates will break things if you don't pass -u!
+                    updateCmd = "pacman -Syu --noconfirm --needed";
+                    installCmd = "pacman -S --noconfirm --needed";
+                }
+                break;
+            case PLATFORM.WINDOWS:
+                // Windows doesn't have a good package manager
+                // Well, it has chocolatey, but it doesn't work right with ARM
+                return false;
+        }
+        if (pkg === VARIANT.SCCACHE && !hasSccache)
+            return false;
+        let execFunc = needSudo ? execShellSudo : execShell;
+        try {
+            if (shouldUpdate)
+                await execFunc(`${updateCmd}`);
+            await execFunc(`${installCmd} ${pkg}`);
+        }
+        catch (error) {
+            throw new Error(getPackageManagerError(error));
+        }
+        return Boolean(await which(pkg));
+    }
+    async installAuto() {
+        if (!await this.installPackageManager()) {
+            await this.installBinary();
+        }
+    }
+    async install(method) {
+        switch (method) {
+            case INSTALL_METHOD.YES:
+                await this.installAuto();
+                break;
+            case INSTALL_METHOD.BINARY:
+                await this.installBinary();
+                break;
+            case INSTALL_METHOD.DETECT:
+                if (!await which(this.variant))
+                    await this.installAuto();
+                break;
+            case INSTALL_METHOD.NO:
+            default:
+                break;
+        }
+        if (!await which(this.variant)) {
+            throw new Error(`Unable to install ${this.variant}. Check prior logs and file a bug report.`);
+        }
+    }
+}
+// platform/stuff helpers //
+function detectPlatform() {
+    switch (external_process_namespaceObject.platform) {
+        case "linux":
+            return PLATFORM.LINUX;
+        case "win32":
+            return PLATFORM.WINDOWS;
+        case "darwin":
+            return PLATFORM.DARWIN;
+        default:
+            throw new Error(`Unsupported platform: ${external_process_namespaceObject.platform}`);
+    }
+}
+function detectArchKey() {
+    switch (external_process_namespaceObject.arch) {
+        case "x64":
+            return "x64";
+        case "arm64":
+            return "aarch64";
+        default:
+            throw new Error(`Unsupported architecture: ${external_process_namespaceObject.arch}`);
+    }
+}
+function selectPackage(variant) {
+    const platform = detectPlatform();
+    const archKey = detectArchKey();
+    let entry;
+    switch (platform) {
+        case PLATFORM.LINUX:
+            entry = LINUX[archKey];
+            break;
+        case PLATFORM.WINDOWS:
+            entry = WINDOWS[archKey];
+            break;
+        case PLATFORM.DARWIN:
+            entry = DARWIN[archKey];
+            break;
+    }
+    if (entry)
+        return entry[variant];
+    else
+        throw new Error(`Unsupported package combination: platform=${platform}, arch=${archKey}, variant=${variant}`);
+}
+function selectMethod(method) {
+    switch (method) {
+        case "yes": return INSTALL_METHOD.YES;
+        case "binary": return INSTALL_METHOD.BINARY;
+        case "detect": return INSTALL_METHOD.DETECT;
+        case "no": return INSTALL_METHOD.NO;
+        default: throw new Error(`Unsupported installation method ${method}.`);
+    }
+}
+function selectVariant(variant) {
+    switch (variant) {
+        case "sccache": return VARIANT.SCCACHE;
+        case "ccache": return VARIANT.CCACHE;
+        default: throw new Error(`Unsupported ccache variant ${variant}.`);
+    }
+}
+// predefined packages //
+// TODO: can this be deduped? automated? generated?
+// Linux //
+const LINUX = {
+    x64: {
+        ccache: new Package(VARIANT.CCACHE, ARCH.X86_64, PLATFORM.LINUX, "4fdc966c46448960f3f9d85cf4430d818c1f4b4618ba0b745d000a396d6bc041", "4.12.2"),
+        sccache: new Package(VARIANT.SCCACHE, ARCH.X86_64, PLATFORM.LINUX, "e381a9675f971082a522907b8381c1054777ea60511043e4c67de5dfddff3029", "v0.12.0"),
+    },
+    aarch64: {
+        ccache: new Package(VARIANT.CCACHE, ARCH.AARCH64, PLATFORM.LINUX, "65ccce8cc26ebb1127207fc55cd96443df56a2d6d74bd84f439db2c91c637d06", "4.12.2"),
+        sccache: new Package(VARIANT.SCCACHE, ARCH.AARCH64, PLATFORM.LINUX, "2f9a8af7cea98e848f92e865a6d5062cfb8c91feeef17417cdd43276b4c7d8af", "v0.12.0"),
+    },
+};
+// Windows //
+const WINDOWS = {
+    x64: {
+        ccache: new Package(VARIANT.CCACHE, ARCH.X86_64, PLATFORM.WINDOWS, "bd73f405e3e80c7f0081ee75dbf9ee44dee64ecfbc3d4316e9a4ede4832f2e41", "4.12.2"),
+        sccache: new Package(VARIANT.SCCACHE, ARCH.X86_64, PLATFORM.WINDOWS, "b0236d379a66b22f6bc9e944adb5b354163015315c3a2aaf7803ce2add758fcd", "v0.12.0"),
+    },
+    aarch64: {
+        ccache: new Package(VARIANT.CCACHE, ARCH.AARCH64, PLATFORM.WINDOWS, "9881a3acf40a5b22eff1c1650b335bd7cf56cf66a6c05cb7d0f53f19b43054f8", "4.12.2"),
+        sccache: new Package(VARIANT.SCCACHE, ARCH.AARCH64, PLATFORM.WINDOWS, "0254597932dcc4fa85f67ac149be29941b96a19f8b1bb0bf71b24640641ab987", "v0.12.0"),
+    },
+};
+// macOS //
+const DARWIN = {
+    x64: {
+        ccache: new Package(VARIANT.CCACHE, ARCH.X86_64, PLATFORM.DARWIN, "3a3429dfd19c206b084204c35667005f0b91cb5716e79cfe7efe796be61a4047", "4.12.2"),
+        sccache: new Package(VARIANT.SCCACHE, ARCH.X86_64, PLATFORM.DARWIN, "dc4b8d99d1aab20d1a2274642444c0bdc3e4a5fb4c6b63c58ff134eea81ccc15", "v0.12.0"),
+    },
+    aarch64: {
+        ccache: new Package(VARIANT.CCACHE, ARCH.AARCH64, PLATFORM.DARWIN, "3a3429dfd19c206b084204c35667005f0b91cb5716e79cfe7efe796be61a4047", "4.12.2"),
+        sccache: new Package(VARIANT.SCCACHE, ARCH.AARCH64, PLATFORM.DARWIN, "0a7e14583e7e136c5b2253990e7ce66668c453a845c710b18873e7205ed8c098", "v0.12.0"),
+    },
+};
 const SELF_CI = external_process_namespaceObject.env["CCACHE_ACTION_CI"] === "true";
 function getPackageManagerError(error) {
     return (`Failed to install ccache via package manager: '${error}'. ` +
@@ -85240,120 +85571,15 @@ async function configure(ccacheVariant, platform) {
         await execShell(`env ${options} sccache --start-server`);
     }
 }
-async function installCcacheMac() {
-    if (getBooleanInput("update-package-index")) {
-        await execShell("brew update");
-    }
-    try {
-        await execShell("brew install ccache");
-    }
-    catch (error) {
-        throw new Error(getPackageManagerError(error));
-    }
-}
-async function installCcacheLinux() {
-    const shouldUpdate = getBooleanInput("update-package-index");
-    try {
-        if (await which("apt-get")) {
-            if (shouldUpdate) {
-                await execShellSudo("apt-get update");
-            }
-            await execShellSudo("apt-get install -y ccache");
-            return;
-        }
-        else if (await which("apk")) {
-            if (shouldUpdate) {
-                await execShell("apk update");
-            }
-            await execShell("apk add ccache");
-            return;
-        }
-        else if (await which("dnf")) {
-            if (shouldUpdate) {
-                await execShell("dnf check-update");
-            }
-            // ccache is part of EPEL repo.
-            await execShell("dnf install -y epel-release");
-            await execShell("dnf install -y ccache");
-            return;
-        }
-    }
-    catch (error) {
-        throw new Error(getPackageManagerError(error));
-    }
-    throw Error("Can't install ccache automatically under this platform, please install it yourself before using this action.");
-}
-async function installCcacheWindows() {
-    await installCcacheFromGitHub("4.9", "windows-x86_64", 
-    // sha256sum of ccache.exe
-    "cf18d274a54b49dcd77f6c289c26eeb89d180cb8329711e607478ed5ef74918c", 
-    // TODO find a better place
-    `${external_process_namespaceObject.env.USERPROFILE}\\.cargo\\bin`, "ccache.exe");
-}
-async function installSccacheMac() {
-    await execShell("brew install sccache");
-}
-async function installSccacheLinux() {
-    let packageName;
-    let sha256;
-    switch (external_process_namespaceObject.arch) {
-        case "x64":
-            packageName = "x86_64-unknown-linux-musl";
-            sha256 = "c205ba0911ce383e90263df8d83e445becccfff1bc0bb2e69ec57d1aa3090a4b";
-            break;
-        case "arm64":
-            packageName = "aarch64-unknown-linux-musl";
-            sha256 = "8df5d557b50aa19c1c818b1a6465454a9dd807917af678f3feae11ee5c9dbe27";
-            break;
-        default:
-            throw new Error(`Unsupported architecture: ${external_process_namespaceObject.arch}`);
-    }
-    await installSccacheFromGitHub("v0.10.0", packageName, sha256, "/usr/local/bin/", "sccache");
-}
-async function installSccacheWindows() {
-    await installSccacheFromGitHub("v0.10.0", "x86_64-pc-windows-msvc", "f3eff6014d973578498dbabcf1510fec2a624043d4035e15f2dc660fb35200d7", 
-    // TODO find a better place
-    `${external_process_namespaceObject.env.USERPROFILE}\\.cargo\\bin`, "sccache.exe");
-}
 async function execShell(cmd) {
     await exec_exec("sh", ["-xc", cmd]);
 }
 async function execShellSudo(cmd) {
-    await execShell("$(which sudo) " + cmd);
-}
-async function installCcacheFromGitHub(version, artifactName, binSha256, binDir, binName) {
-    const archiveName = `ccache-${version}-${artifactName}`;
-    const url = `https://github.com/ccache/ccache/releases/download/v${version}/${archiveName}.zip`;
-    const binPath = external_path_default().join(binDir, binName);
-    await downloadAndExtract(url, external_path_default().join(archiveName, binName), binPath);
-    checkSha256Sum(binPath, binSha256);
-    addPath(binDir);
-}
-async function installSccacheFromGitHub(version, artifactName, binSha256, binDir, binName) {
-    const archiveName = `sccache-${version}-${artifactName}`;
-    const url = `https://github.com/mozilla/sccache/releases/download/${version}/${archiveName}.tar.gz`;
-    const binPath = external_path_default().join(binDir, binName);
-    await downloadAndExtract(url, `*/${binName}`, binPath);
-    checkSha256Sum(binPath, binSha256);
-    addPath(binDir);
-    await execShell(`chmod +x '${binPath}'`);
-}
-async function downloadAndExtract(url, srcFile, dstFile) {
-    const dstDir = external_path_default().dirname(dstFile);
-    if (!external_fs_default().existsSync(dstDir)) {
-        external_fs_default().mkdirSync(dstDir, { recursive: true });
-    }
-    if (url.endsWith(".zip")) {
-        const tmp = external_fs_default().mkdtempSync(external_path_default().join(external_os_default().tmpdir(), ""));
-        const zipName = external_path_default().join(tmp, "dl.zip");
-        await execShell(`curl -L '${url}' -o '${zipName}'`);
-        await execShell(`unzip '${zipName}' -d '${tmp}'`);
-        external_fs_default().copyFileSync(external_path_default().join(tmp, srcFile), dstFile);
-        external_fs_default().rmSync(tmp, { recursive: true });
-    }
-    else {
-        await execShell(`curl -L '${url}' | tar xzf - -O --wildcards '${srcFile}' > '${dstFile}'`);
-    }
+    // if no sudo is available we are probably in a docker container, and don't need it anyways
+    if (await which("sudo"))
+        await execShell("$(which sudo) " + cmd);
+    else
+        await execShell(cmd);
 }
 function checkSha256Sum(path, expectedSha256) {
     const h = external_crypto_default().createHash("sha256");
@@ -85365,30 +85591,20 @@ function checkSha256Sum(path, expectedSha256) {
 }
 async function runInner() {
     const ccacheVariant = getInput("variant");
+    const installMethod = getInput("install");
     saveState("startTimestamp", Date.now());
     saveState("ccacheVariant", ccacheVariant);
     saveState("evictOldFiles", getInput("evict-old-files"));
     saveState("shouldSave", getBooleanInput("save"));
     saveState("appendTimestamp", getBooleanInput("append-timestamp"));
-    let ccachePath = await which(ccacheVariant);
-    if (!ccachePath) {
-        startGroup(`Install ${ccacheVariant}`);
-        const installer = {
-            ["ccache,linux"]: installCcacheLinux,
-            ["ccache,darwin"]: installCcacheMac,
-            ["ccache,win32"]: installCcacheWindows,
-            ["sccache,linux"]: installSccacheLinux,
-            ["sccache,darwin"]: installSccacheMac,
-            ["sccache,win32"]: installSccacheWindows,
-        }[[ccacheVariant, external_process_namespaceObject.platform].join()];
-        if (!installer) {
-            throw Error(`Unsupported platform: ${external_process_namespaceObject.platform}`);
-        }
-        await installer();
-        info(await which(ccacheVariant + ".exe"));
-        ccachePath = await which(ccacheVariant, true);
-        endGroup();
-    }
+    startGroup(`Install ${ccacheVariant}`);
+    const variant = selectVariant(ccacheVariant);
+    const pkg = selectPackage(variant);
+    const method = selectMethod(installMethod);
+    await pkg.install(method);
+    let ccachePath = await which(ccacheVariant, true);
+    info(`${ccacheVariant} installed at ${ccachePath}`);
+    endGroup();
     startGroup("Restore cache");
     await restore(ccacheVariant);
     endGroup();

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -9,9 +9,449 @@ import * as process from "process";
 import * as cache from "@actions/cache";
 import { cacheDir } from "./common";
 
+export enum VARIANT {
+  SCCACHE = "sccache",
+  CCACHE = "ccache",
+}
+
+export enum ARCH {
+  X86_64 = "x86_64",
+  AARCH64 = "aarch64",
+}
+
+export enum PLATFORM {
+  LINUX = "linux",
+  WINDOWS = "windows",
+  DARWIN = "darwin",
+}
+
+export enum INSTALL_METHOD {
+  YES = "yes",
+  BINARY = "binary",
+  DETECT = "detect",
+  NO = "no"
+}
+
+export class Package {
+  constructor(
+    public readonly variant: VARIANT,
+    public readonly arch: ARCH,
+    public readonly platform: PLATFORM,
+    public readonly sha256: string,
+    public readonly version: string,
+  ) { }
+
+  /**
+   * Get the name of this package.
+   * @returns The name of the package used to determine the artifact name and extracted directory.
+   */
+  packageName(): string {
+    const v = this.version;
+
+    if (this.variant === VARIANT.CCACHE) {
+      // ccache darwin is a universal binary
+      if (this.platform === PLATFORM.DARWIN) {
+        return `ccache-${v}-darwin`;
+      }
+
+      return `ccache-${v}-${this.platform}-${this.arch}`;
+    }
+
+    let suffix
+    switch (this.platform) {
+      case PLATFORM.LINUX:
+        suffix = "unknown-linux-musl"
+        break
+      case PLATFORM.WINDOWS:
+        suffix = "pc-windows-msvc"
+        break
+      case PLATFORM.DARWIN:
+        suffix = "apple-darwin"
+        break
+    }
+
+    return `sccache-${v}-${this.arch}-${suffix}`;
+  }
+
+  /**
+   * Get the artifact name of the package.
+   * @returns The fully-qualified artifact name used to download the package.
+   */
+  downloadName(): string {
+    const base = this.packageName();
+
+    // sccache is just tar.gz
+    let extension = "tar.gz"
+
+    if (this.variant === VARIANT.CCACHE) {
+      switch (this.platform) {
+        case PLATFORM.LINUX:
+          extension = "tar.xz"
+          break
+        case PLATFORM.WINDOWS:
+          extension = "zip"
+          break
+        case PLATFORM.DARWIN:
+          break
+      }
+    }
+
+    return `${base}.${extension}`
+  }
+
+  /**
+   * Get the URL to download this package's artifact
+   * @returns The fully-qualified URL to download this package's artifact.
+   */
+  downloadUrl(): string {
+    const artifact = this.downloadName()
+    const repo =
+      this.variant === VARIANT.CCACHE
+        ? "ccache/ccache"
+        : "mozilla/sccache";
+
+    // ccache is a little special sometimes :)
+    const version = this.variant === VARIANT.CCACHE ? `v${this.version}` : `${this.version}`
+
+    return `https://github.com/${repo}/releases/download/${version}/${artifact}`;
+  }
+
+  async downloadAndExtract(srcFile: string, dstFile: string) {
+    const dstDir = path.dirname(dstFile);
+    if (!fs.existsSync(dstDir)) {
+      fs.mkdirSync(dstDir, { recursive: true });
+    }
+
+    const url = this.downloadUrl();
+
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ccache"));
+    const dlName = path.join(tmp, this.downloadName())
+    await execShell(`curl -L '${url}' -o '${dlName}'`)
+
+    if (url.endsWith(".zip")) {
+      await execShell(`unzip '${dlName}' -d '${tmp}'`)
+      fs.copyFileSync(path.join(tmp, srcFile), dstFile)
+      fs.rmSync(tmp, { recursive: true })
+    } else {
+      // windows is a little special :)
+      if (this.platform === PLATFORM.WINDOWS) {
+        const winName = dlName.replaceAll('\\', '/')
+        await execShell(`tar xf "$(cygpath -u ${winName})" -O '${srcFile}' > '${dstFile}'`)
+      }
+      else
+        await execShell(`tar xf '${dlName}' -O '${srcFile}' > '${dstFile}'`)
+    }
+  }
+
+  /**
+   * Install the package.
+   */
+  async installBinary(): Promise<void> {
+    const isWindows = this.platform === PLATFORM.WINDOWS;
+
+    // TODO: evaluate
+    const binDir =
+      this.platform === PLATFORM.WINDOWS
+        ? path.join(process.env.USERPROFILE!, ".cargo", "bin")
+        : "/usr/local/bin";
+
+    // Also prepend install path to PATH var
+    // To prevent pre-existing install potentially clobbering this one
+    core.addPath(binDir);
+
+    const binName = isWindows
+      ? `${this.variant}.exe`
+      : this.variant;
+
+    const binPath = path.join(binDir, binName);
+
+    await this.downloadAndExtract(
+      `${this.packageName()}/${binName}`,
+      binPath);
+
+    // TODO: ccache provides minisig and sccache provides sha256 downloads,
+    // maybe verify w/ that?
+    checkSha256Sum(binPath, this.sha256);
+
+    core.addPath(binDir);
+
+    await execShell(`chmod +x '${binPath}'`);
+  }
+
+  /**
+   * Attempt to install this package from the package manager.
+   * @returns Whether or not it was successfully installed.
+   */
+  async installPackageManager(): Promise<boolean> {
+    const shouldUpdate = core.getBooleanInput("update-package-index");
+    const pkg: string = this.variant
+
+    let updateCmd
+    let installCmd
+    let needSudo = false
+
+    // some distros don't have sccache
+    let hasSccache = true
+
+    switch (this.platform) {
+      case PLATFORM.DARWIN:
+        updateCmd = "brew update"
+        installCmd = "brew install"
+        break
+      case PLATFORM.LINUX:
+        if (await io.which("apt-get")) {
+          updateCmd = "apt-get update"
+          installCmd = "apt-get install -y"
+          hasSccache = false
+          needSudo = true
+        } else if (await io.which("apk")) {
+          updateCmd = "apk update"
+          installCmd = "apk add"
+          hasSccache = false
+        } else if (await io.which("dnf")) {
+          updateCmd = "dnf check-update"
+          installCmd = "dnf install -y"
+
+          // ccache needs epel repo
+          await execShell(`${installCmd} epel-release`)
+        } else if (await io.which("pacman")) {
+          // arch frequently upgrades glibc and such
+          // partial updates will break things if you don't pass -u!
+          updateCmd = "pacman -Syu --noconfirm --needed"
+          installCmd = "pacman -S --noconfirm --needed"
+        }
+        break
+      case PLATFORM.WINDOWS:
+        // Windows doesn't have a good package manager
+        // Well, it has chocolatey, but it doesn't work right with ARM
+        return false
+    }
+
+    if (pkg === VARIANT.SCCACHE && !hasSccache) return false
+
+    let execFunc = needSudo ? execShellSudo : execShell
+
+    try {
+      if (shouldUpdate) await execFunc(`${updateCmd}`)
+      await execFunc(`${installCmd} ${pkg}`)
+    } catch (error) {
+      throw new Error(getPackageManagerError(error));
+    }
+
+    return Boolean(await io.which(pkg))
+  }
+
+  async installAuto(): Promise<void> {
+    if (!await this.installPackageManager()) {
+      await this.installBinary()
+    }
+  }
+
+  async install(method: INSTALL_METHOD): Promise<void> {
+    switch (method) {
+      case INSTALL_METHOD.YES:
+        await this.installAuto()
+        break
+      case INSTALL_METHOD.BINARY:
+        await this.installBinary()
+        break
+      case INSTALL_METHOD.DETECT:
+        if (!await io.which(this.variant)) await this.installAuto()
+        break
+      case INSTALL_METHOD.NO:
+      default:
+        break
+    }
+
+    if (!await io.which(this.variant)) {
+      throw new Error(`Unable to install ${this.variant}. Check prior logs and file a bug report.`)
+    }
+  }
+}
+
+// platform/stuff helpers //
+function detectPlatform(): PLATFORM {
+  switch (process.platform) {
+    case "linux":
+      return PLATFORM.LINUX;
+    case "win32":
+      return PLATFORM.WINDOWS;
+    case "darwin":
+      return PLATFORM.DARWIN;
+    default:
+      throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+}
+
+function detectArchKey(): "x64" | "aarch64" {
+  switch (process.arch) {
+    case "x64":
+      return "x64";
+    case "arm64":
+      return "aarch64";
+    default:
+      throw new Error(`Unsupported architecture: ${process.arch}`);
+  }
+}
+
+export function selectPackage(variant: VARIANT): Package {
+  const platform = detectPlatform()
+  const archKey = detectArchKey()
+
+  let entry
+  switch (platform) {
+    case PLATFORM.LINUX:
+      entry = LINUX[archKey]
+      break
+    case PLATFORM.WINDOWS:
+      entry = WINDOWS[archKey]
+      break
+    case PLATFORM.DARWIN:
+      entry = DARWIN[archKey]
+      break
+  }
+
+  if (entry) return entry[variant]
+  else throw new Error(
+    `Unsupported package combination: platform=${platform}, arch=${archKey}, variant=${variant}`,
+  )
+}
+
+export function selectMethod(method: string): INSTALL_METHOD {
+  switch (method) {
+    case "yes": return INSTALL_METHOD.YES
+    case "binary": return INSTALL_METHOD.BINARY
+    case "detect": return INSTALL_METHOD.DETECT
+    case "no": return INSTALL_METHOD.NO
+    default: throw new Error(`Unsupported installation method ${method}.`)
+  }
+}
+
+export function selectVariant(variant: string): VARIANT {
+  switch (variant) {
+    case "sccache": return VARIANT.SCCACHE
+    case "ccache": return VARIANT.CCACHE
+    default: throw new Error(`Unsupported ccache variant ${variant}.`)
+  }
+}
+
+// predefined packages //
+// TODO: can this be deduped? automated? generated?
+
+// Linux //
+export const LINUX = {
+  x64: {
+    ccache: new Package(
+      VARIANT.CCACHE,
+      ARCH.X86_64,
+      PLATFORM.LINUX,
+      "4fdc966c46448960f3f9d85cf4430d818c1f4b4618ba0b745d000a396d6bc041",
+      "4.12.2",
+    ),
+    sccache: new Package(
+      VARIANT.SCCACHE,
+      ARCH.X86_64,
+      PLATFORM.LINUX,
+      "e381a9675f971082a522907b8381c1054777ea60511043e4c67de5dfddff3029",
+      "v0.12.0",
+    ),
+  },
+
+  aarch64: {
+    ccache: new Package(
+      VARIANT.CCACHE,
+      ARCH.AARCH64,
+      PLATFORM.LINUX,
+      "65ccce8cc26ebb1127207fc55cd96443df56a2d6d74bd84f439db2c91c637d06",
+      "4.12.2",
+    ),
+    sccache: new Package(
+      VARIANT.SCCACHE,
+      ARCH.AARCH64,
+      PLATFORM.LINUX,
+      "2f9a8af7cea98e848f92e865a6d5062cfb8c91feeef17417cdd43276b4c7d8af",
+      "v0.12.0",
+    ),
+  },
+};
+
+// Windows //
+export const WINDOWS = {
+  x64: {
+    ccache: new Package(
+      VARIANT.CCACHE,
+      ARCH.X86_64,
+      PLATFORM.WINDOWS,
+      "bd73f405e3e80c7f0081ee75dbf9ee44dee64ecfbc3d4316e9a4ede4832f2e41",
+      "4.12.2",
+    ),
+    sccache: new Package(
+      VARIANT.SCCACHE,
+      ARCH.X86_64,
+      PLATFORM.WINDOWS,
+      "b0236d379a66b22f6bc9e944adb5b354163015315c3a2aaf7803ce2add758fcd",
+      "v0.12.0",
+    ),
+  },
+
+  aarch64: {
+    ccache: new Package(
+      VARIANT.CCACHE,
+      ARCH.AARCH64,
+      PLATFORM.WINDOWS,
+      "9881a3acf40a5b22eff1c1650b335bd7cf56cf66a6c05cb7d0f53f19b43054f8",
+      "4.12.2",
+    ),
+    sccache: new Package(
+      VARIANT.SCCACHE,
+      ARCH.AARCH64,
+      PLATFORM.WINDOWS,
+      "0254597932dcc4fa85f67ac149be29941b96a19f8b1bb0bf71b24640641ab987",
+      "v0.12.0",
+    ),
+  },
+};
+
+// macOS //
+export const DARWIN = {
+  x64: {
+    ccache: new Package(
+      VARIANT.CCACHE,
+      ARCH.X86_64,
+      PLATFORM.DARWIN,
+      "3a3429dfd19c206b084204c35667005f0b91cb5716e79cfe7efe796be61a4047",
+      "4.12.2",
+    ),
+    sccache: new Package(
+      VARIANT.SCCACHE,
+      ARCH.X86_64,
+      PLATFORM.DARWIN,
+      "dc4b8d99d1aab20d1a2274642444c0bdc3e4a5fb4c6b63c58ff134eea81ccc15",
+      "v0.12.0",
+    ),
+  },
+
+  aarch64: {
+    ccache: new Package(
+      VARIANT.CCACHE,
+      ARCH.AARCH64,
+      PLATFORM.DARWIN,
+      "3a3429dfd19c206b084204c35667005f0b91cb5716e79cfe7efe796be61a4047",
+      "4.12.2",
+    ),
+    sccache: new Package(
+      VARIANT.SCCACHE,
+      ARCH.AARCH64,
+      PLATFORM.DARWIN,
+      "0a7e14583e7e136c5b2253990e7ce66668c453a845c710b18873e7205ed8c098",
+      "v0.12.0",
+    ),
+  },
+};
+
 const SELF_CI = process.env["CCACHE_ACTION_CI"] === "true"
 
-function getPackageManagerError(error: Error | unknown) : string {
+function getPackageManagerError(error: Error | unknown): string {
   return (
     `Failed to install ccache via package manager: '${error}'. ` +
     "Perhaps package manager index is not up to date? " +
@@ -21,7 +461,7 @@ function getPackageManagerError(error: Error | unknown) : string {
 
 // based on https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
 
-async function restore(ccacheVariant : string) : Promise<void> {
+async function restore(ccacheVariant: string): Promise<void> {
   const inputs = {
     primaryKey: core.getInput("key"),
     // https://github.com/actions/cache/blob/73cb7e04054996a98d39095c0b7821a73fb5b3ea/src/utils/actionUtils.ts#L56
@@ -33,7 +473,7 @@ async function restore(ccacheVariant : string) : Promise<void> {
   const primaryKey = inputs.primaryKey ? keyPrefix + (inputs.appendTimestamp ? inputs.primaryKey + "-" : inputs.primaryKey) : keyPrefix;
   const restoreKeys = inputs.restoreKeys.map(k => keyPrefix + k + (inputs.appendTimestamp ? "-" : ""));
   const paths = [cacheDir(ccacheVariant)];
-  
+
   core.saveState("primaryKey", primaryKey);
 
   const shouldRestore = core.getBooleanInput("restore");
@@ -55,9 +495,9 @@ async function restore(ccacheVariant : string) : Promise<void> {
   }
 }
 
-async function configure(ccacheVariant : string, platform : string) : Promise<void> {
+async function configure(ccacheVariant: string, platform: string): Promise<void> {
   const maxSize = core.getInput('max-size');
-  
+
   if (ccacheVariant === "ccache") {
     await execShell(`ccache --set-config=cache_dir='${cacheDir(ccacheVariant)}'`);
     await execShell(`ccache --set-config=max_size='${maxSize}'`);
@@ -83,182 +523,47 @@ async function configure(ccacheVariant : string, platform : string) : Promise<vo
     const options = `SCCACHE_IDLE_TIMEOUT=0 SCCACHE_DIR='${cacheDir(ccacheVariant)}' SCCACHE_CACHE_SIZE='${maxSize}'`;
     await execShell(`env ${options} sccache --start-server`);
   }
-
 }
 
-async function installCcacheMac() : Promise<void> {
-  if (core.getBooleanInput("update-package-index")) {
-    await execShell("brew update");
-  }
-  try {
-    await execShell("brew install ccache");
-  } catch (error) {
-    throw new Error(getPackageManagerError(error));
-  }
-}
-
-async function installCcacheLinux() : Promise<void> {
-  const shouldUpdate = core.getBooleanInput("update-package-index");
-  try {
-    if (await io.which("apt-get")) {
-      if (shouldUpdate) {
-        await execShellSudo("apt-get update");
-      }
-      await execShellSudo("apt-get install -y ccache");
-      return;
-    } else if (await io.which("apk")) {
-      if (shouldUpdate) {
-        await execShell("apk update");
-      }
-      await execShell("apk add ccache");
-      return;
-    } else if (await io.which("dnf")) {
-      if (shouldUpdate) {
-        await execShell("dnf check-update");
-      }
-      // ccache is part of EPEL repo.
-      await execShell("dnf install -y epel-release");
-      await execShell("dnf install -y ccache");
-      return;
-    }
-  } catch (error) {
-    throw new Error(getPackageManagerError(error));
-  }
-
-  throw Error("Can't install ccache automatically under this platform, please install it yourself before using this action.");
-}
-
-async function installCcacheWindows() : Promise<void> {
-  await installCcacheFromGitHub(
-    "4.9",
-    "windows-x86_64",
-    // sha256sum of ccache.exe
-    "cf18d274a54b49dcd77f6c289c26eeb89d180cb8329711e607478ed5ef74918c",
-    // TODO find a better place
-    `${process.env.USERPROFILE}\\.cargo\\bin`,
-    "ccache.exe"
-  );
-}
-
-async function installSccacheMac() : Promise<void> {
-  await execShell("brew install sccache");
-}
-
-async function installSccacheLinux() : Promise<void> {
-  let packageName: string;
-  let sha256: string;
-  switch (process.arch) {
-    case "x64":
-      packageName = "x86_64-unknown-linux-musl";
-      sha256 = "c205ba0911ce383e90263df8d83e445becccfff1bc0bb2e69ec57d1aa3090a4b";
-      break;
-    case "arm64":
-      packageName = "aarch64-unknown-linux-musl";
-      sha256 = "8df5d557b50aa19c1c818b1a6465454a9dd807917af678f3feae11ee5c9dbe27"
-      break;
-    default:
-      throw new Error(`Unsupported architecture: ${process.arch}`);
-  }
-  await installSccacheFromGitHub(
-    "v0.10.0",
-    packageName,
-    sha256,
-    "/usr/local/bin/",
-    "sccache"
-  );
-}
-
-async function installSccacheWindows() : Promise<void> {
-  await installSccacheFromGitHub(
-    "v0.10.0",
-    "x86_64-pc-windows-msvc",
-    "f3eff6014d973578498dbabcf1510fec2a624043d4035e15f2dc660fb35200d7",
-
-    // TODO find a better place
-    `${process.env.USERPROFILE}\\.cargo\\bin`,
-    "sccache.exe"
-  );
-}
-
-async function execShell(cmd : string) {
+async function execShell(cmd: string) {
   await exec.exec("sh", ["-xc", cmd]);
 }
 
-async function execShellSudo(cmd : string) {
-  await execShell("$(which sudo) " + cmd);
+async function execShellSudo(cmd: string) {
+  // if no sudo is available we are probably in a docker container, and don't need it anyways
+  if (await io.which("sudo")) await execShell("$(which sudo) " + cmd);
+  else await execShell(cmd);
 }
 
-async function installCcacheFromGitHub(version : string, artifactName : string, binSha256 : string, binDir : string, binName : string) : Promise<void> {
-  const archiveName = `ccache-${version}-${artifactName}`;
-  const url = `https://github.com/ccache/ccache/releases/download/v${version}/${archiveName}.zip`;
-  const binPath = path.join(binDir, binName);
-  await downloadAndExtract(url, path.join(archiveName, binName), binPath);
-  checkSha256Sum(binPath, binSha256);
-  core.addPath(binDir);
-}
-
-async function installSccacheFromGitHub(version : string, artifactName : string, binSha256 : string, binDir : string, binName : string) : Promise<void> {
-  const archiveName = `sccache-${version}-${artifactName}`;
-  const url = `https://github.com/mozilla/sccache/releases/download/${version}/${archiveName}.tar.gz`;
-  const binPath = path.join(binDir, binName);
-  await downloadAndExtract(url, `*/${binName}`, binPath);
-  checkSha256Sum(binPath, binSha256);
-  core.addPath(binDir);
-  await execShell(`chmod +x '${binPath}'`);
-}
-
-async function downloadAndExtract (url : string, srcFile : string, dstFile : string) {
-  const dstDir = path.dirname(dstFile);
-  if (!fs.existsSync(dstDir)) {
-    fs.mkdirSync(dstDir, { recursive: true });
-  }
-  if (url.endsWith(".zip")) {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), ""));
-    const zipName = path.join(tmp, "dl.zip");
-    await execShell(`curl -L '${url}' -o '${zipName}'`);
-    await execShell(`unzip '${zipName}' -d '${tmp}'`);
-    fs.copyFileSync(path.join(tmp, srcFile), dstFile);
-    fs.rmSync(tmp, { recursive: true });
-  } else {
-    await execShell(`curl -L '${url}' | tar xzf - -O --wildcards '${srcFile}' > '${dstFile}'`);
-  }
-}
-
-function checkSha256Sum (path : string, expectedSha256 : string) {
+function checkSha256Sum(path: string, expectedSha256: string) {
   const h = crypto.createHash("sha256");
   h.update(fs.readFileSync(path));
   const actualSha256 = h.digest("hex");
-  if (actualSha256  !== expectedSha256) {
+  if (actualSha256 !== expectedSha256) {
     throw Error(`SHA256 of ${path} is ${actualSha256}, expected ${expectedSha256}`);
   }
 }
 
-async function runInner() : Promise<void> {
+async function runInner(): Promise<void> {
   const ccacheVariant = core.getInput("variant");
+  const installMethod = core.getInput("install");
   core.saveState("startTimestamp", Date.now());
   core.saveState("ccacheVariant", ccacheVariant);
   core.saveState("evictOldFiles", core.getInput("evict-old-files"));
   core.saveState("shouldSave", core.getBooleanInput("save"));
   core.saveState("appendTimestamp", core.getBooleanInput("append-timestamp"));
-  let ccachePath = await io.which(ccacheVariant);
-  if (!ccachePath) {
-    core.startGroup(`Install ${ccacheVariant}`);
-    const installer = {
-      ["ccache,linux"]: installCcacheLinux,
-      ["ccache,darwin"]: installCcacheMac,
-      ["ccache,win32"]: installCcacheWindows,
-      ["sccache,linux"]: installSccacheLinux,
-      ["sccache,darwin"]: installSccacheMac,
-      ["sccache,win32"]: installSccacheWindows,
-    }[[ccacheVariant, process.platform].join()];
-    if (!installer) {
-      throw Error(`Unsupported platform: ${process.platform}`)
-    }
-    await installer();
-    core.info(await io.which(ccacheVariant + ".exe"));
-    ccachePath = await io.which(ccacheVariant, true);
-    core.endGroup();
-  }
+
+  core.startGroup(`Install ${ccacheVariant}`);
+
+  const variant = selectVariant(ccacheVariant)
+  const pkg = selectPackage(variant)
+  const method = selectMethod(installMethod);
+
+  await pkg.install(method);
+
+  let ccachePath = await io.which(ccacheVariant, true);
+  core.info(`${ccacheVariant} installed at ${ccachePath}`)
+  core.endGroup();
 
   core.startGroup("Restore cache");
   await restore(ccacheVariant);
@@ -270,7 +575,7 @@ async function runInner() : Promise<void> {
   core.endGroup();
 }
 
-async function run() : Promise<void> {
+async function run(): Promise<void> {
   try {
     await runInner();
   } catch (error) {


### PR DESCRIPTION
Defines a `Package` class that takes in platform, version, arch, variant, and sha256. This class primarily has utility functions and is exposed as a singular install function that the `runInner` calls. Automatically handles package managers too, falls back to basic binary installation if that fails.

Also added native Windows/ARM and macOS binaries, and support for `pacman`.

Additionally an `install` option was added to handle the various forms of installation.