### PR TITLE
Add option to forcefully install ccache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     default: false
     required: false
   job-summary:
-    description: "Publish stats as part of the job summary. Set to the title of the job summary section, or to the 
+    description: "Publish stats as part of the job summary. Set to the title of the job summary section, or to the
      empty string to disable this feature. Requires CCache 4.10+"
     default: 'CCache Statistics'
   evict-old-files:
@@ -44,6 +44,10 @@ inputs:
   update-package-index:
     description: "Update package manager index before installing ccache. Enabling this might help when running
       ccache-action in a container or from `act`. Disabling this might speed up the action execution."
+    default: false
+    required: false
+  force-install:
+    description: "Attempt to install the ccache variant, even if it's already installed"
     default: false
     required: false
 runs:

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -67664,14 +67664,16 @@ function checkSha256Sum(path, expectedSha256) {
     }
 }
 async function runInner() {
+    const forceInstall = lib_core.getBooleanInput("force-install");
     const ccacheVariant = lib_core.getInput("variant");
     lib_core.saveState("startTimestamp", Date.now());
     lib_core.saveState("ccacheVariant", ccacheVariant);
     lib_core.saveState("evictOldFiles", lib_core.getInput("evict-old-files"));
+    lib_core.saveState("forceInstall", forceInstall);
     lib_core.saveState("shouldSave", lib_core.getBooleanInput("save"));
     lib_core.saveState("appendTimestamp", lib_core.getBooleanInput("append-timestamp"));
     let ccachePath = await io.which(ccacheVariant);
-    if (!ccachePath) {
+    if (forceInstall || !ccachePath) {
         lib_core.startGroup(`Install ${ccacheVariant}`);
         const installer = {
             ["ccache,linux"]: installCcacheLinux,

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -33,7 +33,7 @@ async function restore(ccacheVariant : string) : Promise<void> {
   const primaryKey = inputs.primaryKey ? keyPrefix + (inputs.appendTimestamp ? inputs.primaryKey + "-" : inputs.primaryKey) : keyPrefix;
   const restoreKeys = inputs.restoreKeys.map(k => keyPrefix + k + (inputs.appendTimestamp ? "-" : ""));
   const paths = [cacheDir(ccacheVariant)];
-  
+
   core.saveState("primaryKey", primaryKey);
 
   const shouldRestore = core.getBooleanInput("restore");
@@ -57,7 +57,7 @@ async function restore(ccacheVariant : string) : Promise<void> {
 
 async function configure(ccacheVariant : string, platform : string) : Promise<void> {
   const maxSize = core.getInput('max-size');
-  
+
   if (ccacheVariant === "ccache") {
     await execShell(`ccache --set-config=cache_dir='${cacheDir(ccacheVariant)}'`);
     await execShell(`ccache --set-config=max_size='${maxSize}'`);
@@ -234,14 +234,17 @@ function checkSha256Sum (path : string, expectedSha256 : string) {
 }
 
 async function runInner() : Promise<void> {
+  const forceInstall = core.getBooleanInput("force-install");
   const ccacheVariant = core.getInput("variant");
+
   core.saveState("startTimestamp", Date.now());
   core.saveState("ccacheVariant", ccacheVariant);
   core.saveState("evictOldFiles", core.getInput("evict-old-files"));
+  core.saveState("forceInstall", forceInstall);
   core.saveState("shouldSave", core.getBooleanInput("save"));
   core.saveState("appendTimestamp", core.getBooleanInput("append-timestamp"));
   let ccachePath = await io.which(ccacheVariant);
-  if (!ccachePath) {
+  if (forceInstall || !ccachePath) {
     core.startGroup(`Install ${ccacheVariant}`);
     const installer = {
       ["ccache,linux"]: installCcacheLinux,


### PR DESCRIPTION
In case one may want to bypass the "do we have ccache yet" check. Most
useful in cases where you wish to update a pre-installed version.

Signed-off-by: crueter <crueter@eden-emu.dev>
