### PR TITLE
ci: automatically advance floating version tags on release

### DIFF
--- a/.github/workflows/update-floating-tags.yml
+++ b/.github/workflows/update-floating-tags.yml
@@ -1,0 +1,51 @@
+name: Update Floating Tags
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  update-tags:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Advance major and minor version tags
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # Ensure TAG matches strict semantic versioning (e.g. v1.2.24)
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Skipping: '$TAG' is not a stable semver tag matching vX.Y.Z."
+            exit 0
+          fi
+
+          echo "Processing release tag: $TAG"
+
+          # Extract major (e.g. v1) and minor (e.g. v1.2)
+          MAJOR="${TAG%%.*}"
+          MINOR="${TAG%.*}"
+
+          echo "Major tag: $MAJOR"
+          echo "Minor tag: $MINOR"
+
+          # Ensure the release tag is available locally.
+          git fetch --tags --force
+
+          # Configure bot identity.
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Force-update annotated floating tags to the release commit.
+          git tag -fa "$MAJOR" -m "Update $MAJOR to $TAG" "$TAG^{commit}"
+          git tag -fa "$MINOR" -m "Update $MINOR to $TAG" "$TAG^{commit}"
+
+          # Force-push both floating tags.
+          git push origin "$MAJOR" "$MINOR" --force


### PR DESCRIPTION
### Summary

This PR adds a GitHub Actions workflow that automatically updates floating major (`v1`) and minor (`v1.2`) tags whenever a new release is published.

### Motivation

As reported in #437, after releasing new patch versions (e.g., `v1.2.22`+), users specifying `@v1` or `@v1.2` were still receiving older releases (`v1.2.20`) because the floating tags were not manually advanced. This led to deprecation warnings on runners targeting Node.js 20.

### How it works

- Listens to the `release: [published]` event.
- Extracts major (`v1`) and minor (`v1.2`) prefixes from the release tag.
- Resolves the release commit using tag peeling (`$TAG^{commit}`).
- Creates annotated floating tags and force-pushes them.

### Verification

- Tested end-to-end on a personal fork with simulated releases.
- Verified that `vX` and `vX.Y` floating tags are successfully advanced to the release commit.
- Verified that the tags are created as annotated tags and pushed successfully.

<details>
<summary>Action Execution Log</summary>

```text
Processing release tag: v9.9.9
Major tag: v9
Minor tag: v9.9
To https://github.com/raycppwizard/ccache-action
 * [new tag]         v9 -> v9
 * [new tag]         v9.9 -> v9.9
```

</details>

Fixes #437